### PR TITLE
fix: put wrong icon for speaker facebook link on speech detail page

### DIFF
--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -136,7 +136,7 @@
                                 :href="speaker.facebook_profile_url"
                             >
                                 <fa
-                                    :icon="['fab', 'linkedin']"
+                                    :icon="['fab', 'facebook']"
                                     aria-hidden="true"
                                     class="mr-2"
                                 ></fa>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

fix: put wrong icon for speaker facebook link on speech detail page