### PR TITLE
fix(tab): enlarge height for slido & hackmd tab

### DIFF
--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -337,6 +337,7 @@ export default {
 
 .speech__slido,
 .speech__hackmd {
-    @apply w-full h-96;
+    @apply w-full;
+    height: 800px;
 }
 </style>

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -210,7 +210,8 @@ export default {
 
 .keynote__slido,
 .keynote__hackmd {
-    @apply w-full h-96;
+    @apply w-full;
+    height: 800px;
 }
 
 .keynote__extLink {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

The height of hackmd & slido tab is too short (396px). Modify the height to 800px.