### PR TITLE
add navbar-dropdown transition

### DIFF
--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -38,12 +38,7 @@
             </div>
             <div>
                 <transition name="core-menu-fade">
-                    <core-menu
-                        v-show="isHovering"
-                        :lg="lg"
-                        :sm="sm"
-                        :isHovering="isHovering"
-                    >
+                    <core-menu v-show="isHovering" :lg="lg" :sm="sm">
                         <transition name="core-menu-mask">
                             <div v-show="isHovering" class="menu-mask"></div>
                         </transition>
@@ -119,10 +114,7 @@ export default {
     opacity: 0;
 }
 .menu-mask {
-    position: absolute;
-    width: 100%;
-    height: 0%;
-    top: 100%;
+    @apply absolute w-full h-0 top-full;
     background: #121023;
 }
 .core-menu-mask-enter-active {

--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -1,6 +1,8 @@
 <template>
     <div
         class="relative flex h-full px-8 justify-center items-center text-left"
+        @mouseenter="showMenu"
+        @mouseleave="hideMenu"
     >
         <div
             class="
@@ -12,8 +14,6 @@
                 items-start
                 cursor-pointer
             "
-            @mouseenter="showMenu"
-            @mouseleave="hideMenu"
         >
             <div
                 id="options-menu"
@@ -36,17 +36,29 @@
                     class="ml-3"
                 ></fa>
             </div>
-            <core-menu v-show="isHovering" :lg="lg" :sm="sm">
-                <slot :hideMenu="hideMenu" name="items"></slot>
-                <core-menu-item
-                    v-for="item in items"
-                    :key="item.value"
-                    :href="item.value"
-                    @click="hideMenu"
-                >
-                    {{ item.label }}
-                </core-menu-item>
-            </core-menu>
+            <div>
+                <transition name="core-menu-fade">
+                    <core-menu
+                        v-show="isHovering"
+                        :lg="lg"
+                        :sm="sm"
+                        :isHovering="isHovering"
+                    >
+                        <transition name="core-menu-mask">
+                            <div v-show="isHovering" class="menu-mask"></div>
+                        </transition>
+                        <slot :hideMenu="hideMenu" name="items"></slot>
+                        <core-menu-item
+                            v-for="item in items"
+                            :key="item.value"
+                            :href="item.value"
+                            @click="hideMenu"
+                        >
+                            {{ item.label }}
+                        </core-menu-item>
+                    </core-menu>
+                </transition>
+            </div>
         </div>
     </div>
 </template>
@@ -94,5 +106,35 @@ export default {
 .options-menu {
     @apply inline-flex w-full h-full justify-center items-center bg-transparent;
     z-index: 100;
+}
+.core-menu-fade-enter-active {
+    transition: all 0.2s;
+}
+.core-menu-fade-leave-active {
+    transition: all 0.5s;
+    transition-delay: 0.2s;
+}
+.core-menu-fade-enter,
+.core-menu-fade-leave-to {
+    opacity: 0;
+}
+.menu-mask {
+    position: absolute;
+    width: 100%;
+    height: 0%;
+    top: 100%;
+    background: #121023;
+}
+.core-menu-mask-enter-active {
+    transition: all 0.2s;
+}
+.core-menu-mask-leave-active {
+    transition: all 0.5s;
+    transition-delay: 0.2s;
+}
+.core-menu-mask-enter,
+.core-menu-mask-leave-to {
+    height: 100%;
+    top: 0px;
 }
 </style>

--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -100,31 +100,24 @@ export default {
     @apply inline-flex w-full h-full justify-center items-center bg-transparent;
     z-index: 100;
 }
-.core-menu-fade-enter-active {
-    transition: all 0.2s;
+.core-menu-fade-enter-active,
+.core-menu-mask-enter-active {
+    @apply transition transition-all duration-200;
 }
-.core-menu-fade-leave-active {
-    transition: all 0.5s;
-    transition-delay: 0.2s;
+.core-menu-fade-leave-active,
+.core-menu-mask-leave-active {
+    @apply transition transition-all duration-500 delay-200;
 }
 .core-menu-fade-enter,
 .core-menu-fade-leave-to {
-    opacity: 0;
+    @apply opacity-0;
 }
 .menu-mask {
     @apply absolute w-full h-0 top-full;
-    background: #121023;
-}
-.core-menu-mask-enter-active {
-    transition: all 0.2s;
-}
-.core-menu-mask-leave-active {
-    transition: all 0.5s;
-    transition-delay: 0.2s;
+    background-color: #121023;
 }
 .core-menu-mask-enter,
 .core-menu-mask-leave-to {
-    height: 100%;
-    top: 0px;
+    @apply h-full top-0;
 }
 </style>

--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -36,24 +36,22 @@
                     class="ml-3"
                 ></fa>
             </div>
-            <div>
-                <transition name="core-menu-fade">
-                    <core-menu v-show="isHovering" :lg="lg" :sm="sm">
-                        <transition name="core-menu-mask">
-                            <div v-show="isHovering" class="menu-mask"></div>
-                        </transition>
-                        <slot :hideMenu="hideMenu" name="items"></slot>
-                        <core-menu-item
-                            v-for="item in items"
-                            :key="item.value"
-                            :href="item.value"
-                            @click="hideMenu"
-                        >
-                            {{ item.label }}
-                        </core-menu-item>
-                    </core-menu>
-                </transition>
-            </div>
+            <transition name="core-menu-fade">
+                <core-menu v-show="isHovering" :lg="lg" :sm="sm">
+                    <transition name="core-menu-mask">
+                        <div v-show="isHovering" class="menu-mask"></div>
+                    </transition>
+                    <slot :hideMenu="hideMenu" name="items"></slot>
+                    <core-menu-item
+                        v-for="item in items"
+                        :key="item.value"
+                        :href="item.value"
+                        @click="hideMenu"
+                    >
+                        {{ item.label }}
+                    </core-menu-item>
+                </core-menu>
+            </transition>
         </div>
     </div>
 </template>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description
<!--Describe what the change is**-->

add navbar-dropdown transition

## Steps to Test This Pull Request

1. Change the position of event trigger when mouseenter and mouseleave
2. Add two transition tags to template. One for fade in and out, the other for being mask of navbar item.
3. Add css relate to transition animation.


## Expected behavior
<!--A clear and concise description of what you expected to happen-->

When navbar items were hovered, the dropdown menu will be active,

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

#231

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
