### PR TITLE
fix(pagewrapper.vue): tune background-size and background-position

### DIFF
--- a/components/core/i18n/PageWrapper.vue
+++ b/components/core/i18n/PageWrapper.vue
@@ -69,6 +69,6 @@ li {
 }
 
 .page-wrapper {
-    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left bg-bgsize;
+    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left bg-scale;
 }
 </style>

--- a/components/core/i18n/PageWrapper.vue
+++ b/components/core/i18n/PageWrapper.vue
@@ -69,6 +69,6 @@ li {
 }
 
 .page-wrapper {
-    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left bg-scale;
+    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left bg-wrapper-size;
 }
 </style>

--- a/components/core/i18n/PageWrapper.vue
+++ b/components/core/i18n/PageWrapper.vue
@@ -69,6 +69,6 @@ li {
 }
 
 .page-wrapper {
-    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left;
+    @apply bg-none lg:bg-wrapper bg-no-repeat bg-wrapper-top-left bg-bgsize;
 }
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
             auto: 'auto',
             cover: 'cover',
             contain: 'contain',
-            scale: '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
+            'wrapper-size': '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
         },
         extend: {
             backgroundImage: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,7 @@ module.exports = {
             auto: 'auto',
             cover: 'cover',
             contain: 'contain',
-            bgsize: '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
+            scale: '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
         },
         extend: {
             backgroundImage: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,12 @@ module.exports = {
             ],
             serif: ['Noto Serif TC', '-apple-system', 'serif'],
         },
+        backgroundSize: {
+            'auto': 'auto',
+            'cover': 'cover',
+            'contain': 'contain',
+            'bgsize': '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
+        },
         extend: {
             backgroundImage: {
                 wrapper:
@@ -20,7 +26,7 @@ module.exports = {
             },
             backgroundPosition: {
                 'wrapper-top-left':
-                    '4% 100px, 4% 958px, 4% 1816px, 96% 200px, 96% 1058px, 96% 1916px, 4% 2674px, 4% 3532px, 4% 4390px, 96% 2774px, 96% 3632px, 96% 4490px',
+                    '4% 100px, 4% 958px, 4% 1816px, 96% 529px, 96% 1125px, 96% 1721px, 4% 2674px, 4% 3532px, 4% 4390px, 96% 2317px, 96% 2913px, 96% 3509px',
             },
         },
         screens: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,10 +14,10 @@ module.exports = {
             serif: ['Noto Serif TC', '-apple-system', 'serif'],
         },
         backgroundSize: {
-            'auto': 'auto',
-            'cover': 'cover',
-            'contain': 'contain',
-            'bgsize': '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
+            auto: 'auto',
+            cover: 'cover',
+            contain: 'contain',
+            bgsize: '7%,5%,7%,7%,7%,7%,7%,5%,7%,7%,7%,7%',
         },
         extend: {
             backgroundImage: {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
Adjust size and position of background image elements

## Steps to Test This Pull Request

Steps to reproduce the behavior:
1. Change `backgroundPosition`, and add `backgroundSize` properties in `tailwind.config`.
2. Add class `bg-bgsize` at `.page-wrapper` in `PageWrapper.vue.`


## Expected behavior
Adjust position of background image elements, and make them smaller.

## Related Issue
#250

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
