### PR TITLE
fix(menu.vue/ navbaritemdropdown.vue): change navbaritems position an…

### DIFF
--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -100,12 +100,10 @@ export default {
     @apply inline-flex w-full h-full justify-center items-center bg-transparent;
     z-index: 100;
 }
-.core-menu-fade-enter-active,
-.core-menu-mask-enter-active {
+.core-menu-fade-enter-active {
     @apply transition transition-all duration-200;
 }
-.core-menu-fade-leave-active,
-.core-menu-mask-leave-active {
+.core-menu-fade-leave-active {
     @apply transition transition-all duration-500 delay-200;
 }
 .core-menu-fade-enter,
@@ -113,7 +111,13 @@ export default {
     @apply opacity-0;
 }
 .menu-mask {
-    @apply absolute w-full h-0 top-full bg-black-900;
+    @apply absolute w-full h-0 top-full bg-black-900 rounded;
+}
+.core-menu-mask-enter-active {
+    @apply transition transition-all duration-200;
+}
+.core-menu-mask-leave-active {
+    @apply transition transition-all duration-700 delay-200;
 }
 .core-menu-mask-enter,
 .core-menu-mask-leave-to {

--- a/components/core/menu/Menu.vue
+++ b/components/core/menu/Menu.vue
@@ -37,7 +37,7 @@ export default {
 <style lang="postcss" scoped>
 .core-menu {
     @apply absolute origin-top-right rounded opacity-80;
-    top: 48px;
+    top: 64px;
     left: 50%;
     transform: translateX(-50%);
     background-color: #1b1a2e;


### PR DESCRIPTION
## Types of changes

* **Bugfix**

## Description

1.The menu items (the semitransparent zone) should be move down

![Aaron Swartz](https://raw.githubusercontent.com/furecool/markdown-img/master/pycon/2022-06-06%20%5B11%2059%2053%5D.png)

![Aaron Swartz](https://raw.githubusercontent.com/furecool/markdown-img/master/pycon/2022-06-06%20%5B11%2058%2059%5D.png)

2.When the animation is over, menu items should not flash. 
![Aaron Swartz](https://raw.githubusercontent.com/furecool/markdown-img/master/pycon/ezgif.com-gif-maker.gif)

## Steps to Test This Pull Request

1. Increase the top value of `.core-menu` in `Menu.vue`
2. Increase the duration value of `.core-menu-mask-leave-active` in `NavBarItemDropdown.vue`

