### PR TITLE
feat: add meta pixel tracker

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -80,6 +80,8 @@ export default {
         '@nuxt/http',
         // https://github.com/nuxt-community/gtm-module
         '@nuxtjs/gtm',
+        // https://github.com/WilliamDASILVA/nuxt-facebook-pixel-module
+        'nuxt-facebook-pixel-module',
         // https://i18n.nuxtjs.org/
         'nuxt-i18n',
         [
@@ -127,6 +129,13 @@ export default {
 
     gtm: {
         id: process.env.GOOGLE_TAG_MANAGER_ID,
+    },
+
+    facebook: {
+        track: 'PageView',
+        pixelId: '561487855431220',
+        autoPageView: true,
+        disabled: false,
     },
 
     markdownit: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12869,6 +12869,14 @@
         "@nuxt/webpack": "2.15.8"
       }
     },
+    "nuxt-facebook-pixel-module": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/nuxt-facebook-pixel-module/-/nuxt-facebook-pixel-module-1.5.0.tgz",
+      "integrity": "sha512-TWM7iv1tLD80NMFDqmv4GrdpE4jkPihcztajeJm6B7TklymR0Jgz3NZ14CzeXRS7FJDJeyZaxmpkcPga1uSiRA==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "nuxt-fontawesome": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/nuxt-fontawesome/-/nuxt-fontawesome-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "core-js": "^3.6.5",
         "dayjs": "^1.10.6",
         "nuxt": "^2.15.3",
+        "nuxt-facebook-pixel-module": "^1.5.0",
         "nuxt-fontawesome": "^0.4.0",
         "nuxt-i18n": "^6.18.0",
         "uuid": "^8.3.2",


### PR DESCRIPTION
### Why

- Support marketing team. Check out [discord discussion](https://discord.com/channels/752904426057892052/755831572586037691/990554820970692699).

### How

- Add [nuxt-facebook-pixel-module](https://www.npmjs.com/package/nuxt-facebook-pixel-module) and enable it by modifying nuxt config.