### PR TITLE
fix(keynotes): Update keynote info for PyCon APAC 2022

### DIFF
--- a/i18n/conference/keynotes.i18n.js
+++ b/i18n/conference/keynotes.i18n.js
@@ -4,11 +4,11 @@ export default genI18nMessages({
     'en-us': {
         title: 'Keynote Speech',
         intro:
-            'PyCon Taiwan invites three speakers to give keynote speeches during the ' +
+            'PyCon APAC 2022 invites four speakers to give keynote speeches during the ' +
             'two-day conference. ' +
             'Each keynote speaker is considered one of the most important figures ' +
             'in their respective fields. ' +
-            'They share their professional experience and the image of their domain’s future.',
+            'They will share their professional experience and the image of their domain’s future.',
         terms: {
             bio: 'Bio',
             talk: 'Talk',
@@ -17,7 +17,7 @@ export default genI18nMessages({
     'zh-hant': {
         title: '主題演講',
         intro:
-            '為期兩天的議程中，將有三位講者於不同場次進行主題演講（Keynote）。' +
+            '為期兩天的議程中，將有四位講者於不同場次進行主題演講（Keynote）。' +
             '主題演講講者都是在全球而言各領域非常頂尖的人士；' +
             '他們將帶來對自己的領域、專案的經驗分享，或者對於未來數年發展的方向與想像。',
         terms: {


### PR DESCRIPTION
## Types of changes
**Bugfix**

## Description
There are some overdue information on keynote page.
Hence this PR update keynote info to the latest.

## Steps to Test This Pull Request

## Expected behavior
The keynote page information is up-to-date

## Related Issue
None

## Additional context
None
