### PR TITLE
fix(sprints): Update summer sprint info for PyCon APAC 2022

### DIFF
--- a/i18n/events/sprints.i18n.js
+++ b/i18n/events/sprints.i18n.js
@@ -4,8 +4,7 @@ export default genI18nMessages({
     'en-us': {
         title: 'Sprints',
         intro:
-            'There will be two sprint events for PyCon APAC 2022, ' +
-            'the first event will be held on 3/13 (Sun.) 10:00 ~ 17:00 (TST).\n\n' +
+            'The Summer Sprint event will be held on 8/14 (Sun.) 09:30 ~ 17:00 (TST).\n\n' +
             'A sprint event gathers open source project owners, contributors, ' +
             'and people who want to contribute but are trying to find a place to start. ' +
             'During a sprint, project hosts bring their unresolved issues or ' +
@@ -34,8 +33,7 @@ export default genI18nMessages({
     'zh-hant': {
         title: '衝刺開發 (Sprints)',
         intro:
-            'PyCon APAC 2022 將會有兩次的衝刺開發 (Sprint)，' +
-            '第一次的活動時間是 3/13 (日) 10:00 ~ 16:30。' +
+            'PyCon APAC 2022 夏季衝刺開發的活動時間是 8/14 (日) 09:30 ~ 17:00。' +
             '衝刺開發是一個聚集開源專案負責人、貢獻者、想貢獻但不知道從何開始的人的活動。' +
             '在活動中，將會有專案領導人帶著他們專案待解決的問題、待開發的功能來現場分享與解說。' +
             '你可以選擇加入自己喜歡的專案，或是帶著自己的專案和大家分享！\n\n' +

--- a/pages/events/sprints.vue
+++ b/pages/events/sprints.vue
@@ -11,15 +11,13 @@
         >
             <template #kktix>
                 <ext-link
-                    href="https://pycontw.kktix.cc/events/pyconsprint2022-1"
+                    href="https://pycontw.kktix.cc/events/pyconapac2022-summersprint"
                     highlight
                     >KKTIX</ext-link
                 >
             </template>
             <template #hackmd>
-                <ext-link
-                    href="https://hackmd.io/oWg32ha4TOG2v8Dt4QDH0A"
-                    highlight
+                <ext-link href="https://hackmd.io/@pycontw/HkXF-Qxc9" highlight
                     >HackMD</ext-link
                 >
             </template>


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->
**New feature**

## Description
Update Summer Sprint info for PyCon APAC 2022

## Steps to Test This Pull Request

## Expected behavior
The updated Summer Sprint info should be displayed on Sprints page

## Related Issue
None

## Additional context
None
