### PR TITLE
Disable CORS on mock server

### DIFF
--- a/mock-server.Dockerfile
+++ b/mock-server.Dockerfile
@@ -6,4 +6,4 @@ RUN npm install -g json-server
 
 COPY db.json routes.json json-server-middlewares.js ./
 
-CMD ["json-server", "--watch", "db.json", "--routes", "routes.json", "--host", "0.0.0.0", "--port", "9876", "--middlewares", "json-server-middlewares.js"]
+CMD ["json-server", "--watch", "db.json", "--routes", "routes.json", "--host", "0.0.0.0", "--port", "9876", "--no-cors", "--middlewares", "json-server-middlewares.js"]


### PR DESCRIPTION
## Types of changes

* **Bugfix**

## Description

This is needed since the mock server is run under a different domain by the docker-compose script. Without disabling CORS, browsers would block the frontend's access to the JSON server.

## Steps to Test This Pull Request

Run `docker-compose -f docker-compose-dev.yml up` and open a page that needs to access API in a modern browser. The browser should block CORS access without this PR.

## Expected behavior

The frontend should correctly access the JSON API.
