### PR TITLE
feat(pageconferenceschedule): use keep-alive and set scrollPosition

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -4,7 +4,7 @@
             <core-header />
         </div>
         <div class="default-layout__body">
-            <Nuxt />
+            <Nuxt keep-alive :keep-alive-props="{ include: includeArr }" />
             <core-footer />
         </div>
     </div>
@@ -18,6 +18,11 @@ export default {
     components: {
         CoreHeader,
         CoreFooter,
+    },
+    data() {
+        return {
+            includeArr: ['PageConferenceSchedule'],
+        }
     },
     head() {
         return {

--- a/pages/conference/schedule.vue
+++ b/pages/conference/schedule.vue
@@ -127,6 +127,18 @@ export default {
         await this.$store.dispatch('$getSchedulesData')
         this.processData()
     },
+    activated() {
+        setTimeout(() => {
+            window.scrollTo(0, this.scrollPosition)
+        }, 0)
+    },
+    deactivated() {
+        this.scrollPosition =
+            window.pageYOffset ||
+            document.documentElement.scrollTop ||
+            document.body.scrollTop ||
+            0
+    },
     methods: {
         processData() {
             this.makeDays()


### PR DESCRIPTION
## Types of changes

* **New feature**

## Description

* Add `keep-alive` on `<Nuxt />` to preserve the state.
* Setting `scrollPosition` that we want to keep in `PageConferenceSchedule`.

## Steps to Test This Pull Request

1. Go to schedule page
2. Click on any speech
3. Go to previous page(schedule page)
4. The position of slider is maintained

## Expected behavior

The tab & slider position should be the same as last visited.

## Related Issue

#183

