### PR TITLE
feat(schedule): add timezone display on schedule time duration

### DIFF
--- a/components/schedule/ScheduleEvent.vue
+++ b/components/schedule/ScheduleEvent.vue
@@ -56,10 +56,14 @@ export default {
         inList: { type: Boolean, default: false },
     },
     data() {
-        const format = 'HH:mm'
+        const timeFormat = 'HH:mm'
+        const timezoneFormat = 'z'
+
         return {
-            format,
-            options: { outputFormat: format },
+            timeFormat,
+            timezoneFormat,
+            timeOptions: { outputFormat: timeFormat },
+            timezoneOptions: { outputFormat: timezoneFormat },
             startPoint: this.$parseDate(this.$padTimezone(this.timelineBegin)),
             icon: {
                 lang: {
@@ -91,13 +95,17 @@ export default {
         duration() {
             const startTime = this.$datetimeToString(
                 this.$padTimezone(this.value.begin_time),
-                this.options,
+                this.timeOptions,
             )
             const endTime = this.$datetimeToString(
                 this.$padTimezone(this.value.end_time),
-                this.options,
+                this.timeOptions,
             )
-            return `${startTime} ~ ${endTime}`
+            const timezone = this.$datetimeToString(
+                this.$padTimezone(this.value.begin_time),
+                this.timezoneOptions,
+            )
+            return `${startTime} ~ ${endTime} (${timezone})`
         },
         roomClass() {
             return `room-${this.value.room}`

--- a/plugins/strings.js
+++ b/plugins/strings.js
@@ -1,9 +1,13 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import customParseFormat from 'dayjs/plugin/customParseFormat'
+import advancedFormat from 'dayjs/plugin/advancedFormat'
+import timezone from 'dayjs/plugin/timezone'
 
 dayjs.extend(utc)
 dayjs.extend(customParseFormat)
+dayjs.extend(advancedFormat)
+dayjs.extend(timezone)
 
 const defaultDatetimeOptions = {
     defaultValue: '',


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description
Add timezone format option plugin to string.js and display on schedule event

resolve #185 
<!--Describe what the change is**-->

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
Please visit page  **/2022/zh-hant/conference/schedule**, 
and see if time duration display like this →  **16:30 ~ 16:45 (GMT+8)**

<!--## Expected behavior-->
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
#185 [Display timezone information on schedule page](https://github.com/pycontw/pycontw-frontend/issues/185)

<!--## Additional context-->
<!--Add any other context or screenshots about the pull request here.-->
