### PR TITLE
Navbar nowrap

### DIFF
--- a/components/core/header/HomeIcon.vue
+++ b/components/core/header/HomeIcon.vue
@@ -26,6 +26,6 @@ export default {
 
 <style scoped>
 .core-homeIcon {
-    @apply text-pink-500;
+    @apply text-pink-500 whitespace-nowrap;
 }
 </style>

--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -140,7 +140,7 @@ export default {
 
 <style lang="postcss" scoped>
 .core-navBarItem {
-    @apply font-bold;
+    @apply font-bold whitespace-nowrap;
 }
 
 .core-navBarItem:hover {

--- a/components/core/header/nav-bar/NavBarItemDropdown.vue
+++ b/components/core/header/nav-bar/NavBarItemDropdown.vue
@@ -97,7 +97,7 @@ export default {
 
 <style lang="postcss" scoped>
 .options-menu {
-    @apply inline-flex w-full h-full justify-center items-center bg-transparent;
+    @apply inline-flex w-full h-full justify-center items-center bg-transparent whitespace-nowrap;
     z-index: 100;
 }
 .core-menu-fade-enter-active {

--- a/components/core/header/nav-bar/ScrollableNavBar.vue
+++ b/components/core/header/nav-bar/ScrollableNavBar.vue
@@ -129,9 +129,9 @@ export default {
         opacity: 0.5;
     }
 }
-@media (max-width: 1193px) {
+@media (max-width: 1440px) {
     .core-scrollableNavBar__slot {
-        width: 1193px;
+        width: 1440px;
     }
     .core-scrollableNavBar {
         @apply relative;


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

Navbar items will auto wrap when browser's width is too small, and we don't wnt it.

## Steps to Test This Pull Request

1. Open any page.
2. Testing RWD for the no-wrape style of navbar item.

## Expected behavior

![Aaron Swartz](https://raw.githubusercontent.com/furecool/markdown-img/master/pycon/navbar-item-nowrap.gif)
