### PR TITLE
[#344] style: update gradient colors of button and text color when hover navbar

### DIFF
--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -113,9 +113,10 @@ export default {
         @apply z-10 border-0 text-primary-100;
         background-image: linear-gradient(
             276.15deg,
-            #72dcb6 0.25%,
-            #3849de 52.99%,
-            #9b4dc3 93.14%
+            #61c8a4 0.25%,
+            #548fcb 34.38%,
+            #3849de 57.05%,
+            #be3692 100%
         );
 
         & span {
@@ -161,9 +162,10 @@ export default {
     content: '';
     background-image: linear-gradient(
         96.26deg,
-        #74dcb6 5.5%,
-        #4454df 50.05%,
-        #9d51c3 82.35%
+        #5fbeab 0%,
+        #66b4e2 34.38%,
+        #4454df 62.5%,
+        #be3692 82.35%
     );
     transition: opacity 0.5s ease-out;
 }

--- a/components/core/buttons/TextButton.vue
+++ b/components/core/buttons/TextButton.vue
@@ -113,10 +113,10 @@ export default {
         @apply z-10 border-0 text-primary-100;
         background-image: linear-gradient(
             276.15deg,
-            #61c8a4 0.25%,
-            #548fcb 34.38%,
-            #3849de 57.05%,
-            #be3692 100%
+            #61c8a4 0.74%,
+            #548fcb 32.18%,
+            #3849de 53.25%,
+            #be3692 93.14%
         );
 
         & span {
@@ -162,9 +162,9 @@ export default {
     content: '';
     background-image: linear-gradient(
         96.26deg,
-        #5fbeab 0%,
-        #66b4e2 34.38%,
-        #4454df 62.5%,
+        #5fbeab 5.5%,
+        #66b4e2 31.92%,
+        #4454df 53.53%,
         #be3692 82.35%
     );
     transition: opacity 0.5s ease-out;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,8 @@ module.exports = {
                     900: '#121023',
                 },
                 pink: {
-                    700: '#e099e1',
+                    500: '#c386ae',
+                    700: '#da8bdc',
                 },
                 secondary: {
                     300: '#a9a6d6',
@@ -59,7 +60,7 @@ module.exports = {
             },
             stroke: (theme) => theme('colors'),
             boxShadow: (theme) => ({
-                'pink-700': `6px 6px 0 theme('colors.pink.700')`,
+                'pink-500': `6px 6px 0 theme('colors.pink.500')`,
             }),
             fill: (theme) => theme('colors'),
             backgroundImage: {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description

- Update the color of `pink-700` to `#da8bdc`
    <img width="761" alt="Screen Shot 2022-11-30 at 12 51 56 AM" src="https://user-images.githubusercontent.com/11289171/204592103-af70b269-0a7d-4cf7-abe9-50afdeecd3f4.png">
- Update the gradient color of `TextButton`
    <img width="1433" alt="Screen Shot 2022-11-30 at 12 46 07 AM" src="https://user-images.githubusercontent.com/11289171/204591448-016c3a53-355e-4fc5-9af1-a1b6ac1abf2d.png"> 
- Update the gradient color of hover `TextButton`
    <img width="1437" alt="Screen Shot 2022-11-30 at 12 46 17 AM" src="https://user-images.githubusercontent.com/11289171/204591459-0d526537-c459-489f-9c26-92a98defe2f9.png"> 
- Figma: https://www.figma.com/file/W3hdepQ7v7ZGYRP6QctBXH/PyCon-Taiwan-%E5%AE%98%E7%B6%B2%E8%A6%96%E8%A6%BA-2022?node-id=5132%3A38362&t=sAc3t8ndcOZ5K7jB-0    

## Expected behavior

https://user-images.githubusercontent.com/11289171/204591812-515bf67d-0cd5-4333-80cb-9cfa8aa1f77b.mov

## Related Issue

https://github.com/pycontw/pycontw-frontend/issues/344

## Additional context
NA
