### PR TITLE
feat: change PyCon APAC -> PyCon TW, 2022 -> 2023

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ COPY store ./store
 COPY utils ./utils
 COPY nuxt.config.js tailwind.config.js .babelrc .env ./
 
-ENV ROUTER_BASE /2022/
-ENV BASE_URL http://pycontw-2022:8000
+ENV ROUTER_BASE /2023/
+ENV BASE_URL http://pycontw-2023:8000
 ENV BUILD_TARGET server
 ENV HOST 0.0.0.0
 ENV API_URL_BROWSER https://tw.pycon.org/prs

--- a/components/core/footer/Footer.vue
+++ b/components/core/footer/Footer.vue
@@ -11,9 +11,12 @@
                     >
                         {{ $t('joinUs') }}
                     </ext-link>
-                    <!-- <locale-link to="/about/staff" class="my-2">{{
-                        $t('staff')
-                    }}</locale-link> -->
+                    <locale-link
+                        v-if="showStaff"
+                        to="/about/staff"
+                        class="my-2"
+                        >{{ $t('staff') }}</locale-link
+                    >
                     <locale-link to="/about/privacy-policy" class="my-2">
                         {{ $t('privacyPolicy') }}
                     </locale-link>
@@ -22,7 +25,9 @@
             <footer-history />
             <footer-icon />
         </div>
-        <div class="core-footer__copyright">© 2023 PyCon TW</div>
+        <div class="core-footer__copyright">
+            © {{ conferenceYear }} {{ conferenceName }}
+        </div>
     </footer>
 </template>
 
@@ -40,6 +45,17 @@ export default {
         ExtLink,
         LocaleLink,
         FooterHistory,
+    },
+    computed: {
+        showStaff() {
+            return this.$store.state.configs.showAboutStaffPage
+        },
+        conferenceName() {
+            return this.$store.state.configs.conferenceName
+        },
+        conferenceYear() {
+            return this.$store.state.configs.conferenceYear
+        },
     },
 }
 </script>

--- a/components/core/footer/Footer.vue
+++ b/components/core/footer/Footer.vue
@@ -6,14 +6,14 @@
             <div class="flex justify-center">
                 <div class="flex flex-col items-center">
                     <ext-link
-                        href="https://forms.gle/DTGfR5znmQCk1PW96"
+                        href="https://forms.gle/vLz3Xev8tUpnRqacA"
                         class="my-2 highlight"
                     >
                         {{ $t('joinUs') }}
                     </ext-link>
-                    <locale-link to="/about/staff" class="my-2">{{
+                    <!-- <locale-link to="/about/staff" class="my-2">{{
                         $t('staff')
-                    }}</locale-link>
+                    }}</locale-link> -->
                     <locale-link to="/about/privacy-policy" class="my-2">
                         {{ $t('privacyPolicy') }}
                     </locale-link>
@@ -22,7 +22,7 @@
             <footer-history />
             <footer-icon />
         </div>
-        <div class="core-footer__copyright">© 2022 PyCon APAC</div>
+        <div class="core-footer__copyright">© 2023 PyCon TW</div>
     </footer>
 </template>
 

--- a/components/core/footer/FooterHistory.vue
+++ b/components/core/footer/FooterHistory.vue
@@ -74,6 +74,10 @@ export default {
                     label: '2021',
                     link: 'https://tw.pycon.org/2021/',
                 },
+                {
+                    label: '2022',
+                    link: 'https://tw.pycon.org/2022/',
+                },
             ],
         }
     },

--- a/components/core/header/HomeIcon.vue
+++ b/components/core/header/HomeIcon.vue
@@ -6,10 +6,10 @@
     >
         <img
             src="~/static/icon.svg"
-            alt="Home icon of PyConTW 2021"
+            alt="Home icon of PyConTW 2023"
             class="w-6"
         />
-        <span class="font-bold ml-2"> PyCon APAC </span>
+        <span class="font-bold ml-2"> PyCon TW </span>
     </locale-link>
 </template>
 

--- a/components/core/header/HomeIcon.vue
+++ b/components/core/header/HomeIcon.vue
@@ -6,10 +6,10 @@
     >
         <img
             src="~/static/icon.svg"
-            alt="Home icon of PyConTW 2023"
+            :alt="`Home icon of ${conferenceName} ${conferenceYear}`"
             class="w-6"
         />
-        <span class="font-bold ml-2"> PyCon TW </span>
+        <span class="font-bold ml-2"> {{ conferenceName }} </span>
     </locale-link>
 </template>
 
@@ -20,6 +20,14 @@ export default {
     name: 'HomeIcon',
     components: {
         LocaleLink,
+    },
+    computed: {
+        conferenceName() {
+            return this.$store.state.configs.conferenceName
+        },
+        conferenceYear() {
+            return this.$store.state.configs.conferenceYear
+        },
     },
 }
 </script>

--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -6,36 +6,36 @@
             :class="getPageClassesByPath('about')"
         >
         </nav-bar-item-dropdown>
-        <!-- <nav-bar-item-dropdown
+        <nav-bar-item-dropdown
             :label="$t('speaking')"
             :items="speakingItems"
             :class="getPageClassesByPath('speaking')"
         >
-        </nav-bar-item-dropdown> -->
-        <locale-link
+        </nav-bar-item-dropdown>
+        <!-- <locale-link
             to="/conference/schedule"
             :class="getPageClassesByPath(null, true, '/conference/schedule')"
             customized
             >{{ $t('schedule') }}</locale-link
-        >
+        > -->
         <locale-link
             to="/events/overview"
             :class="getPageClassesByPath(null, true, '/events/overview')"
             customized
             >{{ $t('overview') }}</locale-link
         >
-        <nav-bar-item-dropdown
+        <!-- <nav-bar-item-dropdown
             :label="$t('conference')"
             :items="conferenceItems"
             :class="getPageClassesByPath('conference')"
         >
-        </nav-bar-item-dropdown>
-        <nav-bar-item-dropdown
+        </nav-bar-item-dropdown> -->
+        <!-- <nav-bar-item-dropdown
             :label="$t('events')"
             :items="eventsItems"
             :class="getPageClassesByPath('events')"
         >
-        </nav-bar-item-dropdown>
+        </nav-bar-item-dropdown> -->
         <!-- <locale-link
             to="/sponsor"
             :class="getPageClassesByPath('sponsor', true)"
@@ -43,12 +43,12 @@
         >
             {{ $t('sponsor') }}
         </locale-link> -->
-        <nav-bar-item-dropdown
+        <!-- <nav-bar-item-dropdown
             :label="$t('registration')"
             :items="registrationItems"
             :class="getPageClassesByPath('registration')"
         >
-        </nav-bar-item-dropdown>
+        </nav-bar-item-dropdown> -->
         <!--
         <locale-link to="/venue" :class="getPageClassesByPath('venue', true)">
             {{ $t('venue') }}

--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -12,47 +12,55 @@
             :class="getPageClassesByPath('speaking')"
         >
         </nav-bar-item-dropdown>
-        <!-- <locale-link
+        <locale-link
+            v-if="showSchedulePage"
             to="/conference/schedule"
             :class="getPageClassesByPath(null, true, '/conference/schedule')"
             customized
             >{{ $t('schedule') }}</locale-link
-        > -->
+        >
         <locale-link
             to="/events/overview"
             :class="getPageClassesByPath(null, true, '/events/overview')"
             customized
             >{{ $t('overview') }}</locale-link
         >
-        <!-- <nav-bar-item-dropdown
+        <nav-bar-item-dropdown
+            v-if="showConferencePage"
             :label="$t('conference')"
             :items="conferenceItems"
             :class="getPageClassesByPath('conference')"
         >
-        </nav-bar-item-dropdown> -->
-        <!-- <nav-bar-item-dropdown
+        </nav-bar-item-dropdown>
+        <nav-bar-item-dropdown
+            v-if="showEventsPage"
             :label="$t('events')"
             :items="eventsItems"
             :class="getPageClassesByPath('events')"
         >
-        </nav-bar-item-dropdown> -->
-        <!-- <locale-link
+        </nav-bar-item-dropdown>
+        <locale-link
+            v-if="showSponsorPage"
             to="/sponsor"
             :class="getPageClassesByPath('sponsor', true)"
             customized
         >
             {{ $t('sponsor') }}
-        </locale-link> -->
-        <!-- <nav-bar-item-dropdown
+        </locale-link>
+        <nav-bar-item-dropdown
+            v-if="showRegistrationPage"
             :label="$t('registration')"
             :items="registrationItems"
             :class="getPageClassesByPath('registration')"
         >
-        </nav-bar-item-dropdown> -->
-        <!--
-        <locale-link to="/venue" :class="getPageClassesByPath('venue', true)">
+        </nav-bar-item-dropdown>
+        <locale-link
+            v-if="showVenuePage"
+            to="/venue"
+            :class="getPageClassesByPath('venue', true)"
+        >
             {{ $t('venue') }}
-        </locale-link> -->
+        </locale-link>
         <ext-link
             :href="signInUrl"
             :class="getPageClassesByPath('signIn', true)"
@@ -78,30 +86,65 @@ export default {
     },
     computed: {
         conferenceItems() {
-            return this.generateI18nItems(navBarItems.conference)
+            return this.generateI18nItems(
+                navBarItems.conference,
+                this.$store.state.configs.conferenceHideItems,
+            )
         },
         eventsItems() {
-            return this.generateI18nItems(navBarItems.events)
+            return this.generateI18nItems(
+                navBarItems.events,
+                this.$store.state.configs.eventsHideItems,
+            )
         },
         speakingItems() {
             return this.generateI18nItems(navBarItems.speaking)
         },
         aboutItems() {
-            return this.generateI18nItems(navBarItems.about)
+            return this.generateI18nItems(
+                navBarItems.about,
+                this.$store.state.configs.aboutHideItems,
+            )
         },
         registrationItems() {
-            return this.generateI18nItems(navBarItems.registration)
+            return this.generateI18nItems(
+                navBarItems.registration,
+                this.$store.state.configs.registrationHideItems,
+            )
         },
         signInUrl() {
             return `https://tw.pycon.org/prs/${this.$i18n.locale}/dashboard/`
         },
+        showSponsorPage() {
+            return this.$store.state.configs.showSponsorPage
+        },
+        showRegistrationPage() {
+            return this.$store.state.configs.showRegistrationPage
+        },
+        showEventsPage() {
+            return this.$store.state.configs.showEventsPage
+        },
+        showConferencePage() {
+            return this.$store.state.configs.showConferencePage
+        },
+        showSpeakingPage() {
+            return this.$store.state.configs.showSpeakingPage
+        },
+        showSchedulePage() {
+            return this.$store.state.configs.showSchedulePage
+        },
+        showVenuePage() {
+            return this.$store.state.configs.showVenuePage
+        },
     },
     methods: {
-        generateI18nItems(items) {
-            return items.map(({ i18nKey, value }) => ({
-                label: this.$i18n.t(i18nKey),
-                value,
-            }))
+        generateI18nItems(items, hideItems = []) {
+            return items
+                .filter((item) => !hideItems.includes(item.i18nKey))
+                .map(({ i18nKey, value }) => ({
+                    label: this.$i18n.t(i18nKey),
+                    value,
+                }))
         },
         getPageClassesByPath(
             category = null,

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -28,48 +28,48 @@
                 :expanding="expandingItem === 'about'"
                 @click.native="toggleAccordion('about')"
             ></nav-bar-item-accordion>
-            <!-- <nav-bar-item-accordion
+            <nav-bar-item-accordion
                 :label="$t('speaking')"
                 :items="speakingItems"
                 :expanding="expandingItem === 'speaking'"
                 @click.native="toggleAccordion('speaking')"
-            ></nav-bar-item-accordion> -->
-            <locale-link
+            ></nav-bar-item-accordion>
+            <!-- <locale-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/conference/schedule"
                 customized
                 >{{ $t('schedule') }}</locale-link
-            >
+            > -->
             <locale-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/events/overview"
                 customized
                 >{{ $t('overview') }}</locale-link
             >
-            <nav-bar-item-accordion
+            <!-- <nav-bar-item-accordion
                 :label="$t('conference')"
                 :items="conferenceItems"
                 :expanding="expandingItem === 'conference'"
                 @click.native="toggleAccordion('conference')"
-            ></nav-bar-item-accordion>
-            <nav-bar-item-accordion
+            ></nav-bar-item-accordion> -->
+            <!-- <nav-bar-item-accordion
                 :label="$t('events')"
                 :items="eventsItems"
                 :expanding="expandingItem === 'events'"
                 @click.native="toggleAccordion('events')"
-            ></nav-bar-item-accordion>
+            ></nav-bar-item-accordion> -->
             <!-- <locale-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/sponsor"
                 customized
                 >{{ $t('sponsor') }}</locale-link
             > -->
-            <nav-bar-item-accordion
+            <!-- <nav-bar-item-accordion
                 :label="$t('registration')"
                 :items="registrationItems"
                 :expanding="expandingItem === 'registration'"
                 @click.native="toggleAccordion('registration')"
-            ></nav-bar-item-accordion>
+            ></nav-bar-item-accordion> -->
             <ext-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 :href="signInUrl"

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -29,47 +29,53 @@
                 @click.native="toggleAccordion('about')"
             ></nav-bar-item-accordion>
             <nav-bar-item-accordion
+                v-if="showSpeakingPage"
                 :label="$t('speaking')"
                 :items="speakingItems"
                 :expanding="expandingItem === 'speaking'"
                 @click.native="toggleAccordion('speaking')"
             ></nav-bar-item-accordion>
-            <!-- <locale-link
+            <locale-link
+                v-if="showSchedulePage"
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/conference/schedule"
                 customized
                 >{{ $t('schedule') }}</locale-link
-            > -->
+            >
             <locale-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/events/overview"
                 customized
                 >{{ $t('overview') }}</locale-link
             >
-            <!-- <nav-bar-item-accordion
+            <nav-bar-item-accordion
+                v-if="showConferencePage"
                 :label="$t('conference')"
                 :items="conferenceItems"
                 :expanding="expandingItem === 'conference'"
                 @click.native="toggleAccordion('conference')"
-            ></nav-bar-item-accordion> -->
-            <!-- <nav-bar-item-accordion
+            ></nav-bar-item-accordion>
+            <nav-bar-item-accordion
+                v-if="showEventsPage"
                 :label="$t('events')"
                 :items="eventsItems"
                 :expanding="expandingItem === 'events'"
                 @click.native="toggleAccordion('events')"
-            ></nav-bar-item-accordion> -->
-            <!-- <locale-link
+            ></nav-bar-item-accordion>
+            <locale-link
+                v-if="showSponsorPage"
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/sponsor"
                 customized
                 >{{ $t('sponsor') }}</locale-link
-            > -->
-            <!-- <nav-bar-item-accordion
+            >
+            <nav-bar-item-accordion
+                v-if="showRegistrationPage"
                 :label="$t('registration')"
                 :items="registrationItems"
                 :expanding="expandingItem === 'registration'"
                 @click.native="toggleAccordion('registration')"
-            ></nav-bar-item-accordion> -->
+            ></nav-bar-item-accordion>
             <ext-link
                 class="core-navBarHamburgerSlideInMenu__item"
                 :href="signInUrl"
@@ -103,22 +109,55 @@ export default {
     },
     computed: {
         conferenceItems() {
-            return this.generateI18nItems(navBarItems.conference)
+            return this.generateI18nItems(
+                navBarItems.conference,
+                this.$store.state.configs.conferenceHideItems,
+            )
         },
         eventsItems() {
-            return this.generateI18nItems(navBarItems.events)
+            return this.generateI18nItems(
+                navBarItems.events,
+                this.$store.state.configs.eventsHideItems,
+            )
         },
         speakingItems() {
             return this.generateI18nItems(navBarItems.speaking)
         },
         aboutItems() {
-            return this.generateI18nItems(navBarItems.about)
+            return this.generateI18nItems(
+                navBarItems.about,
+                this.$store.state.configs.aboutHideItems,
+            )
         },
         registrationItems() {
-            return this.generateI18nItems(navBarItems.registration)
+            return this.generateI18nItems(
+                navBarItems.registration,
+                this.$store.state.configs.registrationHideItems,
+            )
         },
         signInUrl() {
             return `https://tw.pycon.org/prs/${this.$i18n.locale}/dashboard/`
+        },
+        showSponsorPage() {
+            return this.$store.state.configs.showSponsorPage
+        },
+        showRegistrationPage() {
+            return this.$store.state.configs.showRegistrationPage
+        },
+        showEventsPage() {
+            return this.$store.state.configs.showEventsPage
+        },
+        showConferencePage() {
+            return this.$store.state.configs.showConferencePage
+        },
+        showSpeakingPage() {
+            return this.$store.state.configs.showSpeakingPage
+        },
+        showSchedulePage() {
+            return this.$store.state.configs.showSchedulePage
+        },
+        showVenuePage() {
+            return this.$store.state.configs.showVenuePage
         },
     },
     watch: {
@@ -130,11 +169,13 @@ export default {
         },
     },
     methods: {
-        generateI18nItems(items) {
-            return items.map(({ i18nKey, value }) => ({
-                label: this.$i18n.t(i18nKey),
-                value,
-            }))
+        generateI18nItems(items, hideItems = []) {
+            return items
+                .filter((item) => !hideItems.includes(item.i18nKey))
+                .map(({ i18nKey, value }) => ({
+                    label: this.$i18n.t(i18nKey),
+                    value,
+                }))
         },
         toggleMenu() {
             this.isMenuSlidedIn = !this.isMenuSlidedIn

--- a/components/intro/Intro.vue
+++ b/components/intro/Intro.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="intro">
-        <div class="description-wrapper">
+        <div v-if="isShowingApacIntro" class="description-wrapper">
             <div>
                 <core-h2
                     :title="$t('whatIsPyConAPAC')"
@@ -56,6 +56,10 @@ export default {
     },
     props: {
         isBulleted: {
+            type: Boolean,
+            default: true,
+        },
+        isShowingApacIntro: {
             type: Boolean,
             default: true,
         },

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,17 +9,17 @@ services:
       context: .
       dockerfile: mock-server.Dockerfile
 
-  pycontw-2022:
-    container_name: pycontw-2022-frontend-dev
+  pycontw-2023:
+    container_name: pycontw-2023-frontend-dev
     build:
       context: .
       dockerfile: dev.Dockerfile
     volumes:
       - .:/app:cached
       - ./node_modules:/app/node_modules:delegated
-    environment: 
+    environment:
       - BUILD_TARGET=server
-      - ROUTER_BASE=/2022/
+      - ROUTER_BASE=/2023/
       - HOST=0.0.0.0
       - BASE_URL=http://mock-server:9876
       - API_URL_BROWSER=http://0.0.0.0:9876

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.5'
 
 services:
-  pycontw-2022-frontend:
-    container_name: pycontw-2022-frontend
+  pycontw-2023-frontend:
+    container_name: pycontw-2023-frontend
     restart: always
     build:
       context: .
@@ -12,4 +12,4 @@ services:
 networks:
     network:
         external: true
-        name: network-2022
+        name: network-2023

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -27,7 +27,7 @@ export default {
     head() {
         return {
             titleTemplate: (titleChunk) => {
-                const title = 'PyCon APAC 2022'
+                const title = 'PyCon TW 2023'
                 return titleChunk && titleChunk !== title
                     ? `${titleChunk} | ${title}`
                     : title
@@ -41,17 +41,17 @@ export default {
                 {
                     hid: 'description',
                     name: 'description',
-                    content: 'PyCon APAC 2022',
+                    content: 'PyCon TW 2023',
                 },
                 {
                     hid: 'og:title',
                     property: 'og:title',
-                    content: 'PyCon APAC 2022',
+                    content: 'PyCon TW 2023',
                 },
                 {
                     hid: 'og:description',
                     property: 'og:description',
-                    content: 'PyCon APAC 2022',
+                    content: 'PyCon TW 2023',
                 },
                 {
                     hid: 'og:image',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -25,9 +25,11 @@ export default {
         }
     },
     head() {
+        const conferenceName = this.$store.state.configs.conferenceName
+        const conferenceYear = this.$store.state.configs.conferenceYear
         return {
             titleTemplate: (titleChunk) => {
-                const title = 'PyCon TW 2023'
+                const title = `${conferenceName} ${conferenceYear}`
                 return titleChunk && titleChunk !== title
                     ? `${titleChunk} | ${title}`
                     : title
@@ -41,17 +43,17 @@ export default {
                 {
                     hid: 'description',
                     name: 'description',
-                    content: 'PyCon TW 2023',
+                    content: `${conferenceName} ${conferenceYear}`,
                 },
                 {
                     hid: 'og:title',
                     property: 'og:title',
-                    content: 'PyCon TW 2023',
+                    content: `${conferenceName} ${conferenceYear}`,
                 },
                 {
                     hid: 'og:description',
                     property: 'og:description',
-                    content: 'PyCon TW 2023',
+                    content: `${conferenceName} ${conferenceYear}`,
                 },
                 {
                     hid: 'og:image',
@@ -69,7 +71,7 @@ export default {
                 {
                     rel: 'icon',
                     type: 'image/x-icon',
-                    href: '/2022/favicon.ico',
+                    href: `/${conferenceYear}/favicon.ico`,
                 },
                 {
                     rel: 'preconnect',
@@ -91,17 +93,17 @@ export default {
                 {
                     rel: 'alternate',
                     hreflang: 'x-default',
-                    href: 'https://tw.pycon.org/2021/en-us',
+                    href: `https://tw.pycon.org/${conferenceYear}/en-us`,
                 },
                 {
                     rel: 'alternate',
                     hreflang: 'en-us',
-                    href: 'https://tw.pycon.org/2021/en-us',
+                    href: `https://tw.pycon.org/${conferenceYear}/en-us`,
                 },
                 {
                     rel: 'alternate',
                     hreflang: 'zh-hant-tw',
-                    href: 'https://tw.pycon.org/2021/zh-hant',
+                    href: `https://tw.pycon.org/${conferenceYear}/zh-hant`,
                 },
             ],
             script: [
@@ -112,7 +114,7 @@ export default {
                         '@type': 'Organization',
                         name: 'PyCon Taiwan',
                         url: 'https://tw.pycon.org',
-                        logo: 'https://tw.pycon.org/2022/og-img.jpg',
+                        logo: `https://tw.pycon.org/${conferenceYear}/og-img.jpg`,
                         sameAs: [
                             'https://www.facebook.com/pycontw/',
                             'https://twitter.com/PyConTW/',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,5 @@
 const DEFAULT_BASE_URL = 'http://staging.pycon.tw/prs'
-const DEFAULT_ROUTER_BASE = '/2022/'
+const DEFAULT_ROUTER_BASE = '/2023/'
 const DEFAULT_BUILD_TARGET = 'static'
 const DEFAULT_VUE_DEVTOOL = false
 

--- a/pages/about/privacy-policy.vue
+++ b/pages/about/privacy-policy.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <banner>
-            <core-h1 :title="`2022 ${$t('title')}`"></core-h1>
+            <core-h1 :title="`2023 ${$t('title')}`"></core-h1>
             <i18n path="pageAbstract" tag="p" class="pageAbstract">
                 <template #br><br /></template>
             </i18n>

--- a/pages/about/privacy-policy.vue
+++ b/pages/about/privacy-policy.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <banner>
-            <core-h1 :title="`2023 ${$t('title')}`"></core-h1>
+            <core-h1 :title="`${conferenceYear} ${$t('title')}`"></core-h1>
             <i18n path="pageAbstract" tag="p" class="pageAbstract">
                 <template #br><br /></template>
             </i18n>
@@ -118,6 +118,11 @@ export default {
         return {
             authorizationIcon: require('~/static/img/footer/ccby-sa3_0.svg'),
         }
+    },
+    computed: {
+        conferenceYear() {
+            return this.$store.state.configs.conferenceYear
+        },
     },
     head() {
         return {

--- a/pages/events/overview.vue
+++ b/pages/events/overview.vue
@@ -21,8 +21,8 @@
                     :tag-color="event.tagColor"
                     :img-url="event.imgUrl"
                     :img-alt="event.imgAlt"
-                    :to="event.to"
-                    :href="event.href"
+                    :to="event.openToView && event.to"
+                    :href="event.openToView && event.href"
                 ></event-card>
             </event-card-collection>
         </i18n-page-wrapper>
@@ -59,6 +59,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/young-inspirers.png'),
                     imgAlt: 'Young Inspirers',
                     to: '/conference/young-inspirers',
+                    openToView: false,
                 },
                 {
                     tag: 'sprint',
@@ -67,6 +68,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/sprint.png'),
                     imgAlt: 'Sprint',
                     to: '/events/sprints',
+                    openToView: false,
                 },
                 {
                     tag: 'pycast',
@@ -75,6 +77,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/pycast.png'),
                     imgAlt: 'PyCast',
                     href: 'https://podcasts.apple.com/podcast/id1559843325',
+                    openToView: true,
                 },
                 {
                     tag: 'keynote',
@@ -83,6 +86,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/keynote.png'),
                     imgAlt: 'Keynote',
                     to: '/conference/keynotes',
+                    openToView: false,
                 },
                 {
                     tag: 'talk',
@@ -91,6 +95,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/talk.png'),
                     imgAlt: 'Talk',
                     to: '/conference/talks',
+                    openToView: false,
                 },
                 {
                     tag: 'tutorial',
@@ -99,6 +104,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/tutorial.png'),
                     imgAlt: 'Tutorial',
                     to: '/conference/tutorials',
+                    openToView: false,
                 },
                 {
                     tag: 'openSpace',
@@ -107,6 +113,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/open-space.png'),
                     imgAlt: 'Open Space',
                     to: '/events/open-spaces',
+                    openToView: false,
                 },
                 {
                     tag: 'lightningTalk',
@@ -114,6 +121,7 @@ export default {
                     tagColor: 'green',
                     imgUrl: require('~/static/img/events/overview/lightning-talk.png'),
                     imgAlt: 'Lightning Talk',
+                    openToView: false,
                 },
                 {
                     tag: 'pynight',
@@ -121,6 +129,7 @@ export default {
                     tagColor: 'green',
                     imgUrl: require('~/static/img/events/overview/pynight.png'),
                     imgAlt: 'PyNight',
+                    openToView: false,
                 },
                 {
                     tag: 'jobFair',
@@ -129,6 +138,7 @@ export default {
                     imgUrl: require('~/static/img/events/overview/job-fair.png'),
                     imgAlt: 'Job Fair',
                     to: '/events/jobs',
+                    openToView: false,
                 },
             ],
         }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
                     <img
                         class="title-img"
                         src="~/static/index-title.svg"
-                        alt="Title of PyCon APAC 2022"
+                        alt="Title of PyCon TW 2023"
                     />
                 </div>
                 <div

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,7 +17,7 @@
                     <img
                         class="title-img"
                         src="~/static/index-title.svg"
-                        alt="Title of PyCon TW 2023"
+                        :alt="`Title of ${conferenceName} ${conferenceYear}`"
                     />
                 </div>
                 <div
@@ -44,7 +44,7 @@
                         {{ $t('callForProposals') }}
                     </text-button>
                 </div>
-                <div class="text-button-wrapper">
+                <div v-if="isShowingScheduleButton" class="text-button-wrapper">
                     <text-button to="/conference/schedule">{{
                         $t('checkEvents')
                     }}</text-button>
@@ -53,7 +53,10 @@
         </div>
 
         <i18n-page-wrapper>
-            <intro :is-bulleted="isBulleted"></intro>
+            <intro
+                :is-showing-apac-intro="showIndexAPACSection"
+                :is-bulleted="isBulleted"
+            ></intro>
             <div class="bulletin-section">
                 <core-h2
                     :title="$t('bulletinList')"
@@ -62,7 +65,11 @@
                 ></core-h2>
                 <bulletin-card-collection></bulletin-card-collection>
             </div>
-            <div id="sponsor" class="sponsor-section">
+            <div
+                v-if="showIndexSponsorSection"
+                id="sponsor"
+                class="sponsor-section"
+            >
                 <core-h2
                     :title="$t('sponsorList')"
                     :is-bulleted="isBulleted"
@@ -123,7 +130,6 @@ export default {
     data() {
         return {
             isOpened: false,
-            isCallingForProposals: false,
             selectedSponsor: {},
         }
     },
@@ -138,6 +144,24 @@ export default {
                 }
             }
             return true
+        },
+        conferenceName() {
+            return this.$store.state.configs.conferenceName
+        },
+        conferenceYear() {
+            return this.$store.state.configs.conferenceYear
+        },
+        isCallingForProposals() {
+            return this.$store.state.configs.showSpeakingPage
+        },
+        isShowingScheduleButton() {
+            return this.$store.state.configs.showSchedulePage
+        },
+        showIndexSponsorSection() {
+            return this.$store.state.configs.showIndexSponsorSection
+        },
+        showIndexAPACSection() {
+            return this.$store.state.configs.showIndexAPACSection
         },
     },
     created() {

--- a/store/index.js
+++ b/store/index.js
@@ -9,6 +9,24 @@ export const state = () => ({
     speechesData: [],
     speechData: {},
     relatedData: [],
+    configs: {
+        conferenceName: 'PyCon TW',
+        conferenceYear: '2023',
+        showSpeakingPage: true,
+        showAboutStaffPage: false,
+        showSchedulePage: false,
+        showSponsorPage: false,
+        showRegistrationPage: false,
+        showEventsPage: false,
+        showConferencePage: false,
+        showVenuePage: false,
+        showIndexSponsorSection: false,
+        showIndexAPACSection: false,
+        aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
+        eventsHideItems: [], // ['sprints', 'openSpaces', 'jobs']
+        conferenceHideItems: [], // ['keynotes', 'talks', 'tutorials', 'youngInspirers']
+        registrationHideItems: [], // ['tickets', 'financialAid']
+    },
 })
 
 export const mutations = {


### PR DESCRIPTION
## Types of changes

* **New feature**

## Description
Change all "PyCon APAC" into "PyCon TW", 2022 -> 2023 for the CfP stage.

## Steps to Test This Pull Request
1. npm run dev

## Expected behavior
1. Showing `speaking/`, `overview/` pages with conference name as PyCon TW.
2. Hiding `about/staff/`, `schedule/`, `conference/`, `events/`, `registration/` pages

Closes #342 