### PR TITLE
feat: add switch to decide whether showing overview page or not

### DIFF
--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -21,6 +21,7 @@
             >{{ $t('schedule') }}</locale-link
         >
         <locale-link
+            v-if="showEventOverviewPage"
             to="/events/overview"
             :class="getPageClassesByPath(null, true, '/events/overview')"
             customized
@@ -121,6 +122,9 @@ export default {
         },
         showRegistrationPage() {
             return this.$store.state.configs.showRegistrationPage
+        },
+        showEventOverviewPage() {
+            return this.$store.state.configs.showEventOverviewPage
         },
         showEventsPage() {
             return this.$store.state.configs.showEventsPage

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -43,6 +43,7 @@
                 >{{ $t('schedule') }}</locale-link
             >
             <locale-link
+                v-if="showEventOverviewPage"
                 class="core-navBarHamburgerSlideInMenu__item"
                 to="/events/overview"
                 customized
@@ -146,6 +147,9 @@ export default {
         },
         showEventsPage() {
             return this.$store.state.configs.showEventsPage
+        },
+        showEventOverviewPage() {
+            return this.$store.state.configs.showEventOverviewPage
         },
         showConferencePage() {
             return this.$store.state.configs.showConferencePage

--- a/store/index.js
+++ b/store/index.js
@@ -17,6 +17,7 @@ export const state = () => ({
         showSchedulePage: false,
         showSponsorPage: false,
         showRegistrationPage: false,
+        showEventOverviewPage: false,
         showEventsPage: false,
         showConferencePage: false,
         showVenuePage: false,


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description
feat: add switch to decide whether showing overview page or not

## Steps to Test This Pull Request
1. Go to home page and check if `events/overview` is displayed on the navigator or hamburger  navigator

## Expected behavior
<img width="1408" alt="image" src="https://user-images.githubusercontent.com/18432820/213395311-6c473f1a-eb84-4101-b962-5b4b00ec5c13.png">
<img width="718" alt="image" src="https://user-images.githubusercontent.com/18432820/213435764-3d664c9c-9ab2-4389-a955-0d6ee85c6167.png">


## Related Issue
fix #370 

