### PR TITLE
fix: webcache 404 error page

### DIFF
--- a/configs/router.js
+++ b/configs/router.js
@@ -1,0 +1,69 @@
+// this file is a config for package: "@nuxtjs/router" override nuxt router
+// cacheUrlMatcher is a white list for webCache page
+// this is a workaround to resolve google search console
+// related issue: https://github.com/vuejs/vue-router/issues/2042
+
+import Router from 'vue-router'
+
+const cacheUrlMatchers = [
+    {
+        hostname: 'yandexwebcache.net',
+        pathname: '/yandbtm',
+    },
+    {
+        hostname: 'webcache.googleusercontent.com',
+        pathname: '/search',
+    },
+]
+
+// Check if fullUrl is cache resource
+const isCachedUrl = (fullUrl = '') => {
+    if (process.server) return null
+
+    const url = new URL(fullUrl)
+
+    return cacheUrlMatchers.some(
+        ({ hostname, pathname }) =>
+            url.hostname === hostname && url.pathname === pathname,
+    )
+}
+
+export function createRouter(
+    ssrContext,
+    createDefaultRouter,
+    routerOptions,
+    config,
+) {
+    const defaultRouter = createDefaultRouter(ssrContext, config)
+    const options = routerOptions || defaultRouter.options
+
+    // Check for current location is cache
+    const isCache = process.client && isCachedUrl(window.location.href)
+    // Change mode if we in cache, to prevent "Uncaught DOMException"
+    const mode = isCache ? 'abstract' : options.mode
+
+    const resultOptions = {
+        ...options,
+        mode,
+    }
+    const router = new Router(resultOptions)
+    // Set nuxt replaced methods
+    router.push = defaultRouter.push
+
+    // Set init route in cache
+    if (isCache) {
+        const origRouterResolve = router.resolve.bind(router)
+        // Get fullpath of original page
+        const { route } = window.__NUXT__.state
+        const { fullPath } = route
+
+        // Mock first resolve call
+        router.resolve = () => {
+            // Unmock all others
+            router.resolve = origRouterResolve
+            return origRouterResolve(fullPath)
+        }
+    }
+
+    return router
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -79,6 +79,13 @@ export default {
         '@nuxtjs/tailwindcss',
         // https://github.com/nuxt-community/dotenv-module
         '@nuxtjs/dotenv',
+        [
+            '@nuxtjs/router',
+            {
+                path: 'configs',
+                keepDefaultRouter: true,
+            },
+        ],
     ],
 
     // Modules (https://go.nuxtjs.dev/config-modules)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3172,6 +3172,24 @@
                 "http-proxy-middleware": "^1.0.6"
             }
         },
+        "@nuxtjs/router": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@nuxtjs/router/-/router-1.7.0.tgz",
+            "integrity": "sha512-7OXEYqE/7uM/7Bx1Ab8udyFgBux9h5IisJqNLMNa5hxt9oBtF43VXHEnnQV4FtYpKyg8ysTFDT9FJlC+tGqpQg==",
+            "dev": true,
+            "requires": {
+                "consola": "^2.15.3",
+                "defu": "^5.0.0"
+            },
+            "dependencies": {
+                "defu": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/defu/-/defu-5.0.1.tgz",
+                    "integrity": "sha512-EPS1carKg+dkEVy3qNTqIdp2qV7mUP08nIsupfwQpz++slCVRw7qbQyWvSTig+kFPwz2XXp5/kIIkH+CwrJKkQ==",
+                    "dev": true
+                }
+            }
+        },
         "@nuxtjs/tailwindcss": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@nuxtjs/tailwindcss/-/tailwindcss-4.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "@nuxtjs/eslint-config": "^3.1.0",
         "@nuxtjs/eslint-module": "^2.0.0",
         "@nuxtjs/gtm": "^2.4.0",
+        "@nuxtjs/router": "^1.7.0",
         "@nuxtjs/tailwindcss": "^4.1.0",
         "@vue/test-utils": "^1.1.0",
         "babel-core": "7.0.0-bridge.0",


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->


* **Bugfix**


## Description
<!--Describe what the change is**-->

fix 404 error page on google cache page

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
open in google link site:https://tw.pycon.org
choose in search result "頁庫存擋"
you open page https://webcache.googleusercontent.com/search?q=cache:9er0RXJ1v60J:https://tw.pycon.org/&cd=1&hl=zh-TW&ct=clnk&gl=tw&cd=1&hl=ru&ct=clnk&gl=ua
then page will redirect to https://tw.pycon.org/2023/en-us/search?q=cache%3A9er0RXJ1v60J%3Ahttps%3A%2F%2Ftw.pycon.org%2F&cd=1&hl=zh-TW&ct=clnk&gl=tw

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
show correctly on webcache page

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
refer to https://github.com/vuejs/vue-router/issues/2042

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
