### PR TITLE
fix broken image on the landing title

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -207,13 +207,13 @@ export default {
 }
 .landing__title {
     position: relative;
-    top: 2.5rem;
+    top: 4.5rem;
     background-image: url('~@/static/landing-title-rwd.png');
     background-repeat: no-repeat;
     background-position-x: center;
     background-position-y: 2rem;
     background-size: 100%;
-    min-height: 50vh;
+    min-height: 55vh;
     min-width: 100vw;
 }
 @media (min-width: 768px) {
@@ -223,6 +223,7 @@ export default {
         background-position-y: 0;
     }
     .landing__title {
+        top: 2.5rem;
         background-image: url('~@/static/landing-title.png');
         background-repeat: no-repeat;
         background-position-x: 0;


### PR DESCRIPTION
## Types of changes
* **Bugfix** change the viewport and top padding of the landing title to fix the broken image issue


## Description
The overflow of the image happens in width between 580+px to 768px (first media query change)
After adjusting the top padding and vertical view, the image can fit properly.


## Expected behavior
No broken image on all width sizes on the view

## Related Issue
#382 
