### PR TITLE
feat- add 2023 sprints page

### DIFF
--- a/i18n/events/sprints.i18n.js
+++ b/i18n/events/sprints.i18n.js
@@ -4,55 +4,53 @@ export default genI18nMessages({
     'en-us': {
         title: 'Sprints',
         intro:
-            'The Summer Sprint event will be held on 8/14 (Sun.) 09:30 ~ 17:00 (TST).\n\n' +
-            'A sprint event gathers open source project owners, contributors, ' +
-            'and people who want to contribute but are trying to find a place to start. ' +
-            'During a sprint, project hosts bring their unresolved issues or ' +
-            'new features under development and share with everyone. ' +
+            'The Summer Sprint event will be held on 8/20 (Sun.) 10:00 ~ 17:00 (TST).\n\n' +
+            'A sprint event gathers open source project owners, ' +
+            'contributors, and people who want to contribute but are trying to find a place to start. ' +
+            'During a sprint, project hosts bring their unresolved issues or new ' +
+            'features under development and share with everyone. ' +
             'You can join a project of your choice, or bring your own project here!\n\n' +
-            'For those who already know fundamentals of Python and ' +
-            'want to participate open source projects, ' +
-            'but don’t know where to start, sprints are great opportunities to ' +
-            'get yourself involved! As for project hosts, ' +
-            'this is a great chance for you to find people with similar interests, ' +
+            'For those who already know the fundamentals of Python and want to participate in open source projects, ' +
+            'but don’t know where to start, sprints are good opportunities to get yourself involved! ' +
+            'As for project hosts, this is a great chance for you to find people with similar interests, ' +
             'having face-to-face interactions with contributors, ' +
-            'and getting new contributors to your project’s development! ' +
-            'Be prepared to get your hands dirty!',
+            'and getting new contributors to your project’s development! Be prepared to get you busy!\n\n' +
+            'On-site\n\n' +
+            'After relaxing the lockdown restrictions policy for Covid-19, ' +
+            'we will host the event on site. Before the event, ' +
+            'we will announce the project in our website and PyCon TW FB. ' +
+            'At the opening of the event, we arrange the project hosts to introduce their project in brief. ' +
+            'The participants can choose the interested project and join the development of the project. ' +
+            'The project hosts can keep communicating with the attendees face to face. ' +
+            'We encourage project hosts and participants to keep developing the project even after the event, ' +
+            'so we will make a discord channel in PyCon TW.',
         mode: 'Mode',
         modeDescriptions: [
-            'Due to COVID-19, we will host the event in Gather Town. ' +
-                'The project hosts can keep communicating with the attendees online. ' +
-                'For each project, we would build a unique room in Gather Town space. ' +
-                'We also prepare a Google Meet link for a backup plan if we face a poor internet connection.',
-            'Please be aware, due to the policy of Gather Town, ' +
-                'you have to be 18 years old or above to join this event.',
             "Please visit {kktix} if you'd like to join as an attendee, " +
-                "or fill out {form} if you'd like to be a project owner in this event!",
+                "or fill out this {form} if you'd like to be a project owner in this event!",
             'You can find the project list on {hackmd}.',
         ],
-        form: 'this Google Form',
+        form: 'Google Form',
     },
     'zh-hant': {
         title: '衝刺開發 (Sprints)',
         intro:
-            'PyCon APAC 2022 夏季衝刺開發的活動時間是 8/14 (日) 09:30 ~ 17:00。' +
+            'PyCon TW 2023 夏季衝刺開發的活動時間是 8/20 (日) 10:00 ~ 17:00。' +
             '衝刺開發是一個聚集開源專案負責人、貢獻者、想貢獻但不知道從何開始的人的活動。' +
             '在活動中，將會有專案領導人帶著他們專案待解決的問題、待開發的功能來現場分享與解說。' +
-            '你可以選擇加入自己喜歡的專案，或是帶著自己的專案和大家分享！\n\n' +
+            '你可以選擇加入自己喜歡的專案，或是帶著自己的專案和大家分享！' +
             '對已經有一定 Python 基礎的人，想參與開源專案但不知如何加入，' +
             '或者害羞怕自己不了解該專案環境的人，參加衝刺開發是個大展身手的好時機；' +
-            '而對於專案領導人來說，這是一個找到志同道合的朋友、面對面和貢獻者交流、' +
-            '帶領更多新人加入開發的好機會！',
+            '而對於專案領導人來說，這是一個找到志同道合的朋友、面對面和貢獻者交流、帶領更多新人加入開發的好機會！\n\n' +
+            '終於在疫情告一段落之後，活動將重新回到實體場地中進行，' +
+            '讓對專案有興趣的參與者一起面對面地與專案主持人進行衝刺開發。' +
+            '活動前我們會有一些關於參與專案的簡介，專案主持人在活動開始時也會有一些詳細的介紹，' +
+            '活動中參與者可以選擇有興趣的專案參加，並於活動後我們也歡迎各位持續地參加專案開發。',
         mode: '模式',
         modeDescriptions: [
-            '今年由於疫情的因素我們將 Sprints 搬至 Gather Town 舉行，' +
-                '讓專案主持人和會眾能放心的在線上盡情的與專案主持人進行衝刺開發。' +
-                '對每一個專案，我們會開設在 Gather 的場地內的一個專屬房間，在此專屬房間一起討論，' +
-                '並有 Google Meet 連結作為連線不佳時的備用方案。',
-            '請留意，因應 Gather Town 的政策，本次活動僅開放年滿 18 歲以上的會眾參加。',
             '參加者報名請至 {kktix}、報名專案主持人請至 {form}。',
             '專案列表可參考 {hackmd}。',
         ],
-        form: '此份 Google 表單',
+        form: 'Google 表單',
     },
 })

--- a/pages/events/sprints.vue
+++ b/pages/events/sprints.vue
@@ -15,14 +15,14 @@
                 >
                     <template #kktix>
                         <ext-link
-                            href="https://pycontw.kktix.cc/events/pyconapac2022-summersprint"
+                            href="https://pycontw.kktix.cc/events/2023-sprints"
                             highlight
                             >KKTIX</ext-link
                         >
                     </template>
                     <template #hackmd>
                         <ext-link
-                            href="https://hackmd.io/@pycontw/HkXF-Qxc9"
+                            href="https://hackmd.io/R98LEB4MSxm4AeExmxuZnA"
                             highlight
                             >HackMD</ext-link
                         >
@@ -39,7 +39,7 @@
         </two-col-wrapper>
         <iframe
             class="hackmd"
-            src="https://hackmd.io/@pycontw/HkXF-Qxc9"
+            src="https://hackmd.io/R98LEB4MSxm4AeExmxuZnA"
         ></iframe>
     </i18n-page-wrapper>
 </template>

--- a/pages/events/sprints.vue
+++ b/pages/events/sprints.vue
@@ -29,7 +29,7 @@
                     </template>
                     <template #form>
                         <ext-link
-                            href="https://forms.gle/Htt9REPE6M7iVKZL9"
+                            href="https://forms.gle/UjpBvHmqSaULoX2s7"
                             highlight
                             >{{ $t('form') }}</ext-link
                         >

--- a/store/index.js
+++ b/store/index.js
@@ -25,7 +25,7 @@ export const state = () => ({
         showIndexSponsorSection: true,
         showIndexSecondaryBtn: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
-        eventsHideItems: ['sprints', 'openSpaces'], // ['sprints', 'openSpaces', 'jobs']
+        eventsHideItems: ['openSpaces'], // ['sprints', 'openSpaces', 'jobs']
         conferenceHideItems: ['keynotes', 'youngInspirers'], // ['keynotes', 'talks', 'tutorials', 'youngInspirers']
         registrationHideItems: [], // ['tickets', 'financialAid']
         venueHideItems: [], // ['venueInfo', 'accommodation']


### PR DESCRIPTION
## Description
Update page related to sprints and upload to 2023 website

## Steps to Test This Pull Request
1. click events/sprints in header
2. check if En/Zh content updated to 2023 information at Google [Doc](https://docs.google.com/document/d/1jZ9v_Fsc0dgWFB7TmQ8b4mclJBkqPoc9bwjQ9sdU12I/edit#heading=h.z437yptlh9hp) 

## Expected behavior
<img width="1197" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/86618855-41f1-45da-9335-d95d89546855">
<img width="1202" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/e647d611-a133-47c3-b337-bb29b4ea8618">

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
#427 
