### PR TITLE
fix(keynote): prevent replaceAll on null when speaker_name_en_us is empty

### DIFF
--- a/components/schedule/ScheduleEvent.vue
+++ b/components/schedule/ScheduleEvent.vue
@@ -130,7 +130,7 @@ export default {
                 event_id: eventId,
                 speakers,
             } = this.value
-            if (eventType === 'keynote') {
+            if (eventType === 'keynote' && speakers[0].en_us) {
                 const keynoteSpeakerId = speakers[0].en_us
                     .replaceAll(' ', '_')
                     .replaceAll('.', '')

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -168,9 +168,11 @@ export default {
     },
     methods: {
         getKeynoteId(keynote) {
-            return keynote.speaker.name_en_us
-                .replaceAll(' ', '_')
-                .replaceAll('.', '')
+            if (keynote.speaker.name_en_us) {
+                return keynote.speaker.name_en_us
+                    .replaceAll(' ', '_')
+                    .replaceAll('.', '')
+            }
         },
         getAttributeByLocale(data, attr) {
             const localeMap = { 'en-us': 'en_us', 'zh-hant': 'zh_hant' }


### PR DESCRIPTION


<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**


## Description
* prevent replaceAll on null when speaker_name_en_us is empty

## Steps to Test This Pull Request
1. go to page http://localhost:3000/2023/zh-hant/conference/keynotes or http://localhost:3000/2023/en-us/conference/keynotes

## Expected behavior
![localhost_3000_2023_zh-hant_conference_keynotes](https://github.com/pycontw/pycontw-frontend/assets/18432820/b56d1a51-974e-4326-8cb5-bd139a6e1906)


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
