### PR TITLE
fix(index/sponsorCard): adjust sponsorCard__tag position and remove logo border radius

### DIFF
--- a/components/sponsors/SponsorCard.vue
+++ b/components/sponsors/SponsorCard.vue
@@ -48,7 +48,6 @@ export default {
 .sponsorCard > img {
     @apply absolute object-contain;
     width: calc(100% - 10px);
-    border-radius: inherit;
 }
 
 .sponsorCard.-small {
@@ -58,7 +57,7 @@ export default {
 
 .sponsorCard__tag {
     @apply absolute flex h-5 w-full items-center justify-center text-[12px] font-semibold;
-    bottom: 20px;
+    bottom: 13px;
     background-color: hsla(321, 32%, 62%, 1);
     color: #ffffff;
 


### PR DESCRIPTION

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
adjust tag position and remove border radius of sponsor logo

## Steps to Test This Pull Request
1. go to index page

## Expected behavior
Before
<img width="1074" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/18432820/4f80f71c-9255-4e2c-bac8-b404c84cb674">


After
<img width="966" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/18432820/ef77aec2-6c96-47de-ae4f-1bbad6fd6db8">



## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
