### PR TITLE
feat-typhoon pop up info

### DIFF
--- a/i18n/index.i18n.js
+++ b/i18n/index.i18n.js
@@ -18,6 +18,7 @@ export default genI18nMessages({
         callForProposals: 'Call for Proposals',
         checkEvents: 'Event Schedule',
         buyTickets: 'Buy Tickets Now',
+        typhoonInfoTitle: 'Typhoon Preparedness Measures',
         typhoonInfo:
             "The event on September 2nd-3rd, 2023, depends on Taipei City Government's Closure Announcement. " +
             'Stay updated via PyCon Taiwan official website and social media.{br}' +
@@ -42,6 +43,7 @@ export default genI18nMessages({
         callForProposals: '投稿募集',
         checkEvents: '查看議程',
         buyTickets: '立即購票',
+        typhoonInfoTitle: '颱風因應措施',
         typhoonInfo:
             '本次活動期間 (2023 年 09 月 02 日至 03 日) 將依照「臺北市政府之停班公告」決定是否舉行，' +
             '最新消息請關注「PyCon Taiwan 官網與社群媒體」之公告。{br}' +

--- a/i18n/index.i18n.js
+++ b/i18n/index.i18n.js
@@ -18,6 +18,12 @@ export default genI18nMessages({
         callForProposals: 'Call for Proposals',
         checkEvents: 'Event Schedule',
         buyTickets: 'Buy Tickets Now',
+        typhoonInfo:
+            "The event on September 2nd-3rd, 2023, depends on Taipei City Government's Closure Announcement. " +
+            'Stay updated via PyCon Taiwan official website and social media.{br}' +
+            'The organizer reserves the right to make final revisions, changes, interpretations of the event, and cancellations of “PyCon TW 2023”.{br}' +
+            "Let's say it:" +
+            '"PyCon TW 2023 will definitely be held successfully!"',
     },
     'zh-hant': {
         pyconWelcome: '歡迎來到 PyCon TW 2023',
@@ -36,5 +42,10 @@ export default genI18nMessages({
         callForProposals: '投稿募集',
         checkEvents: '查看議程',
         buyTickets: '立即購票',
+        typhoonInfo:
+            '本次活動期間 (2023 年 09 月 02 日至 03 日) 將依照「臺北市政府之停班公告」決定是否舉行，' +
+            '最新消息請關注「PyCon Taiwan 官網與社群媒體」之公告。{br}' +
+            '主辦單位保有對「PyCon TW 2023」的最終修改、變更、活動解釋及取消本活動之權利。{br}' +
+            '請跟我一起唸：PyCon TW 2023 一定可以順利舉行！',
     },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18533,6 +18533,11 @@
                 }
             }
         },
+        "sweetalert2": {
+            "version": "11.7.27",
+            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.7.27.tgz",
+            "integrity": "sha512-QbRXGQn1sb7HEhzA/K2xtWIwQHh/qkSbb1w6jYcTql2xy17876lTREEt1D4X6Q0x2wHtfUjKJ+Cb8IVkRoq7DQ=="
+        },
         "swiper": {
             "version": "6.7.5",
             "resolved": "https://registry.npmjs.org/swiper/-/swiper-6.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "nuxt": "^2.15.3",
         "nuxt-facebook-pixel-module": "^1.5.0",
         "nuxt-fontawesome": "^0.4.0",
+        "sweetalert2": "^11.7.27",
         "swiper": "^6.7.5",
         "uuid": "^8.3.2",
         "vue-awesome-swiper": "^4.1.1",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="landing">
         <div class="landing__background flex pt-4 md:pt-24">
+            <button class="btn btn-default btn-fill" @click="showSwal">
+                <i18n tag="p" path="typhoonInfo">
+                    <template #br><br /></template>
+                </i18n>
+            </button>
             <div class="landing__background__items">
                 <img
                     class="landing__background__items__meter"
@@ -64,7 +69,6 @@
                 </div>
             </div>
         </div>
-
         <I18nPageWrapper>
             <Intro :is-bulleted="isBulleted"></Intro>
             <div class="pt-12 lg:mx-auto lg:w-full">
@@ -130,6 +134,7 @@ import SponsorCard from '@/components/sponsors/SponsorCard'
 import Modal from '@/components/core/modal/Modal'
 import SponsorCardCollection from '@/components/sponsors/SponsorCardCollection'
 import Intro from '@/components/intro/Intro'
+import swal from 'sweetalert2'
 
 export default {
     i18n,
@@ -189,6 +194,13 @@ export default {
             const localeMap = { 'en-us': 'en_us', 'zh-hant': 'zh_hant' }
             const attributeName = `${attr}_${localeMap[this.$i18n.locale]}`
             return data[attributeName]
+        },
+        showSwal() {
+            swal({
+                title: `Notification`,
+                buttonsStyling: false,
+                confirmButtonClass: 'btn btn-success btn-fill',
+            })
         },
     },
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,11 +1,6 @@
 <template>
     <div class="landing">
         <div class="landing__background flex pt-4 md:pt-24">
-            <button class="btn btn-default btn-fill" @click="showSwal">
-                <i18n tag="p" path="typhoonInfo">
-                    <template #br><br /></template>
-                </i18n>
-            </button>
             <div class="landing__background__items">
                 <img
                     class="landing__background__items__meter"
@@ -135,6 +130,7 @@ import Modal from '@/components/core/modal/Modal'
 import SponsorCardCollection from '@/components/sponsors/SponsorCardCollection'
 import Intro from '@/components/intro/Intro'
 import swal from 'sweetalert2'
+import 'sweetalert2/dist/sweetalert2.css'
 
 export default {
     i18n,
@@ -185,6 +181,9 @@ export default {
     created() {
         this.$store.dispatch('$getSponsorsData')
     },
+    mounted() {
+        this.showSwal()
+    },
     methods: {
         showModal(sponsor) {
             this.isOpened = true
@@ -196,7 +195,7 @@ export default {
             return data[attributeName]
         },
         showSwal() {
-            swal({
+            return new swal({  // eslint-disable-line
                 title: `Notification`,
                 buttonsStyling: false,
                 confirmButtonClass: 'btn btn-success btn-fill',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -196,9 +196,11 @@ export default {
         },
         showSwal() {
             return new swal({  // eslint-disable-line
-                title: `Notification`,
-                buttonsStyling: false,
-                confirmButtonClass: 'btn btn-success btn-fill',
+                title: this.$i18n.t('typhoonInfoTitle'),
+                html: this.$i18n
+                    .t('typhoonInfo')
+                    .replaceAll('{br}', '<br/><br/>'),
+                buttonsStyling: true,
             })
         },
     },


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
* **New feature**

## Description
<!--Describe what the change is**-->
Show typhoon information once entering landing page

<img width="1440" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/18432820/20c13d13-d4af-4c73-9dfe-3875fc6a1e86">
<img width="1440" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/18432820/332c7596-645d-4a53-b9d0-eae002b6cffd">


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
#453 
## Additional context
<!--Add any other context or screenshots about the pull request here.-->
