### PR TITLE
hide proposal system temporarily

### DIFF
--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -64,7 +64,7 @@
         >
         </nav-bar-item-dropdown>
         <ext-link
-            v-if="showProposalSystem"
+            v-if="showProposalSystemPage"
             :href="proposalSystemUrl"
             :class="getPageClassesByPath('proposalSystemUrl', true)"
         >
@@ -147,6 +147,9 @@ export default {
         },
         showVenuePage() {
             return this.$store.state.configs.showVenuePage
+        },
+        showProposalSystemPage() {
+            return this.$store.state.configs.showProposalSystemPage
         },
     },
     methods: {

--- a/components/core/header/nav-bar/NavBar.vue
+++ b/components/core/header/nav-bar/NavBar.vue
@@ -64,6 +64,7 @@
         >
         </nav-bar-item-dropdown>
         <ext-link
+            v-if="showProposalSystem"
             :href="proposalSystemUrl"
             :class="getPageClassesByPath('proposalSystemUrl', true)"
         >

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -82,6 +82,7 @@
                 @click.native="toggleAccordion('venue')"
             ></nav-bar-item-accordion>
             <ext-link
+                v-if="showProposalSystem"
                 class="core-navBarHamburgerSlideInMenu__item"
                 :href="proposalSystemUrl"
                 >{{ $t('proposalSystemUrl') }}</ext-link

--- a/components/core/header/nav-bar/NavBarHamburger.vue
+++ b/components/core/header/nav-bar/NavBarHamburger.vue
@@ -82,7 +82,7 @@
                 @click.native="toggleAccordion('venue')"
             ></nav-bar-item-accordion>
             <ext-link
-                v-if="showProposalSystem"
+                v-if="showProposalSystemPage"
                 class="core-navBarHamburgerSlideInMenu__item"
                 :href="proposalSystemUrl"
                 >{{ $t('proposalSystemUrl') }}</ext-link
@@ -173,6 +173,9 @@ export default {
         },
         showVenuePage() {
             return this.$store.state.configs.showVenuePage
+        },
+        showProposalSystemPage() {
+            return this.$store.state.configs.showProposalSystemPage
         },
     },
     watch: {

--- a/i18n/speaking/cfp.i18n.js
+++ b/i18n/speaking/cfp.i18n.js
@@ -20,7 +20,7 @@ export default genI18nMessages({
             howToSubmit: {
                 title: 'How to Submit Your Proposal',
                 description: [
-                    'You need to {signUp} for a new account on our system. With an activated account, you can fill up the speaker profile and create new proposals through the {proposalSystem} page.',
+                    'You need to sign up for a new account on our system. With an activated account, you can fill up the speaker profile and create new proposals through the proposal system page.',
                     'We encourage you to submit the proposal as early as possible. You are welcomed to submit multiple proposals.',
                     'Since COVID-19 become stable, we recommend attending the meeting venue in person. If you have personal reasons, you may ask to give your talk or tutorial remotely.',
                 ],
@@ -151,7 +151,7 @@ export default genI18nMessages({
             howToSubmit: {
                 title: '提交稿件',
                 description: [
-                    '您需要先在系統上 {signUp} 一個新的帳號。在啟用您的帳號之後，就可以填寫講者資訊，並從 {proposalSystem} 頁面中建立新的投搞。我們強烈建議您儘早送出您的投稿。',
+                    '您需要先在系統上註冊一個新的帳號。在啟用您的帳號之後，就可以填寫講者資訊，並從投稿系統頁面中建立新的投搞。我們強烈建議您儘早送出您的投稿。',
                     '因應 COVID-19 疫情逐漸穩定，今年演講與專業課程將會以實體會議形式舉辦，建議講者來到現場與會眾互動。若有不可抗力之因素，您仍可以依照自身狀況選擇是否親自前來。',
                 ],
                 steps: [],

--- a/store/index.js
+++ b/store/index.js
@@ -22,6 +22,7 @@ export const state = () => ({
         showEventsPage: false,
         showConferencePage: false,
         showVenuePage: false,
+        showProposalSystem: false,
         showIndexSponsorSection: false,
         showIndexSecondaryBtn: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']

--- a/store/index.js
+++ b/store/index.js
@@ -22,7 +22,7 @@ export const state = () => ({
         showEventsPage: false,
         showConferencePage: false,
         showVenuePage: false,
-        showProposalSystem: false,
+        showProposalSystemPage: true,
         showIndexSponsorSection: false,
         showIndexSecondaryBtn: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']

--- a/store/index.js
+++ b/store/index.js
@@ -22,7 +22,7 @@ export const state = () => ({
         showEventsPage: false,
         showConferencePage: false,
         showVenuePage: false,
-        showProposalSystemPage: true,
+        showProposalSystemPage: false,
         showIndexSponsorSection: false,
         showIndexSecondaryBtn: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']


### PR DESCRIPTION
Hide proposal system temporarily before bugs fixed.
Add parameter that makes hiding proposal system easier.
More specifically, hide or remove links for items with red frame as following:
<img width="538" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/3671856c-f028-415a-b20a-aed490c66b3d">
<img width="536" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/3e91f5f5-1afb-4791-8d39-7ff3ac29195b">

