### PR TITLE
fix(homepage): adjust the join_us button setting

### DIFF
--- a/configs/pageLanding.js
+++ b/configs/pageLanding.js
@@ -12,7 +12,7 @@ export const landingButtonConfig = {
         textKey: 'joinUs',
         isPrimary: false,
         isBordered: true,
-        isLarge: false,
+        isLarge: true,
     },
     CFP: {
         isExternalLink: false,


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
<!--Describe what the change is**-->
fix #467 issue

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
1. Navigate to 'https://tw.pycon.org/2024/zh-hant'.
2. Observe the "Join Us" and "Call for Proposals" buttons in the middle section of the homepage.

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
1. The button size should be consistent.

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
