### PR TITLE
chore: hide cfp button on index page

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -156,7 +156,7 @@ export default {
     data() {
         return {
             isOpened: false,
-            primaryButton: landingButtonConfig.CFP,
+            primaryButton: landingButtonConfig.PRIMARY_JOIN_US,
             secondaryButton: landingButtonConfig.SECONDARY_JOIN_US,
             selectedSponsor: {},
         }

--- a/store/index.js
+++ b/store/index.js
@@ -24,7 +24,7 @@ export const state = () => ({
         showVenuePage: false,
         showProposalSystemPage: false,
         showIndexSponsorSection: false,
-        showIndexSecondaryBtn: true,
+        showIndexSecondaryBtn: false,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
         eventsHideItems: [], // ['sprints', 'openSpaces', 'jobs']
         conferenceHideItems: [], // ['keynotes', 'talks', 'tutorials', 'panelDiscussion']


### PR DESCRIPTION
Please note that the CD (netlify) has broken due to other issue, but the change work on my local (preview as follow):
<img width="1495" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/24987826/18f4f9f3-6e9e-410f-ae73-e394a53f82b0">
