### PR TITLE
fix: outdated og-img

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -58,7 +58,7 @@ export default {
                 {
                     hid: 'og:image',
                     property: 'og:image',
-                    content: 'https://tw.pycon.org/{conferenceYear}/og-img.jpg',
+                    content: `https://tw.pycon.org/${conferenceYear}/og-img.jpg`,
                 },
                 {
                     hid: 'og:url',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -58,7 +58,7 @@ export default {
                 {
                     hid: 'og:image',
                     property: 'og:image',
-                    content: 'https://tw.pycon.org/2023/og-img.jpg',
+                    content: 'https://tw.pycon.org/{conferenceYear}/og-img.jpg',
                 },
                 {
                     hid: 'og:url',


### PR DESCRIPTION
Update og-img to current year

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
Fix the bug on outdated og img when the official website link shared

* **Bugfix**


## Description
<!--Describe what the change is**-->
![image](https://github.com/pycontw/pycontw-frontend/assets/26858727/6048b1db-9429-4cc9-8d3e-a35a4bb2813e)


## Steps to Test This Pull Request
1. Share the link of "https://tw.pycon.org/"
2. Check if the img is 2024 (especially the date of conference on the img) with the link

