### PR TITLE
feat(keynote): toggle keynote and fix js error in server

### DIFF
--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -173,8 +173,8 @@ export default {
         getKeynoteId(keynote) {
             if (keynote.speaker.name_en_us) {
                 return keynote.speaker.name_en_us
-                    .replaceAll(' ', '_')
-                    .replaceAll('.', '')
+                    .replace(/[' ']/g, '_')
+                    .replace(/['.']/g, '')
             }
         },
         getAttributeByLocale(data, attr) {

--- a/store/index.js
+++ b/store/index.js
@@ -20,14 +20,14 @@ export const state = () => ({
         showRegistrationPage: true,
         showEventOverviewPage: true,
         showEventsPage: false,
-        showConferencePage: false,
+        showConferencePage: true,
         showVenuePage: false,
         showProposalSystemPage: true,
         showIndexSponsorSection: true,
         showIndexSecondaryBtn: false,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
         eventsHideItems: [], // ['sprints', 'openSpaces', 'jobs']
-        conferenceHideItems: [], // ['keynotes', 'talks', 'tutorials', 'panelDiscussion']
+        conferenceHideItems: ['talks', 'tutorials', 'panelDiscussion'], // ['keynotes', 'talks', 'tutorials', 'panelDiscussion']
         registrationHideItems: ['tickets'], // ['tickets', 'financialAid']
         venueHideItems: [], // ['venueInfo', 'accommodation']
     },


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
Fix #526 
* **New feature**
1. Toggle On keynote page.
2. Fix the javascript replaceAll error, because of old node js version.

## Description
<!--Describe what the change is**-->
1. Go to path `2024/zh-hant/conference/keynotes`

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
keynote Screenshot:
![截圖 2024-06-04 下午9 07 29](https://github.com/pycontw/pycontw-frontend/assets/62326692/1f7ed8d5-179d-41ca-96e9-b8ebfb6fda76)
