### PR TITLE
fix(keynote): center the img in keynote

### DIFF
--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -213,7 +213,7 @@ export default {
     @apply mb-20 md:mb-28;
 }
 .keynote__photo {
-    @apply mx-auto my-2 h-24 w-24 md:h-28 md:w-28;
+    @apply mx-auto my-2 flex h-24 w-24 justify-center md:h-28 md:w-28;
 }
 
 .keynote__photo img {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes

* **Bugfix**


## Description
- center the keynote profile img.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
Go to keynote page and observe the img is center?
https://deploy-preview-542--classy-granita-bc2b5a.netlify.app/en-us/conference/keynotes

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
