### PR TITLE
fix(modal): remove inner photo rounded for sponsor logos

### DIFF
--- a/components/core/modal/Modal.vue
+++ b/components/core/modal/Modal.vue
@@ -126,7 +126,7 @@ export default {
     transform: translateX(0px);
 }
 .lightBox__photo > img {
-    @apply absolute rounded-[inherit] object-contain;
+    @apply absolute object-contain;
     width: calc(100% - 10px);
 }
 .img__bg {


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
<!--Describe what the change is**-->
Logo affected by rounded feat for inner photo in sponsor card. 
Remove it to show the complete content.
![image](https://github.com/pycontw/pycontw-frontend/assets/26858727/5bb7b04d-ad2c-4dad-8836-1fbd55be4468)


## Steps to Test This Pull Request
1. Go to path/2024/zh-hant and click on sponsor logos to check if photos are fixed.

e.g: 
<img width="891" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/ea71a803-9a80-4bc5-9721-7722d674a78c">
