### PR TITLE
feat(speech): toggle talks and tutorials pages

### DIFF
--- a/i18n/conference/speeches.i18n.js
+++ b/i18n/conference/speeches.i18n.js
@@ -6,12 +6,12 @@ export default genI18nMessages({
             title: 'Talks',
             intro:
                 'The two conference days are packed with talks about Python by speakers' +
-                ' from Taiwan and around the world. The talks will be either 15-, 30-,' +
-                ' or 45-minute long. Three tracks of talks will be delivered simultaneously,' +
-                ' all with different topics and difficulties. We suggest you to make a schedule' +
-                ' beforehand, and choose what you want ot listen based on your interests.' +
-                ' Many people take notes on the program schedule before the meeting so they don’t ' +
-                'run to wrong places.',
+                ' from Taiwan and around the world. The talks will be either 15, 30,' +
+                ' or 45 minutes long. Three tracks of talks will be delivered simultaneously,' +
+                ' all with different topics and difficulties. We suggest you make a schedule' +
+                ' beforehand, and choose what you want to listen based on your interests.' +
+                ' Many people take notes on the program schedule before the meeting so they don’t' +
+                ' run to the wrong places.',
             categoryFilter: 'Category',
         },
         tutorials: {

--- a/store/index.js
+++ b/store/index.js
@@ -27,7 +27,7 @@ export const state = () => ({
         showIndexSecondaryBtn: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
         eventsHideItems: [], // ['sprints', 'openSpaces', 'jobs']
-        conferenceHideItems: ['talks', 'tutorials', 'panelDiscussion'], // ['keynotes', 'talks', 'tutorials', 'panelDiscussion']
+        conferenceHideItems: ['panelDiscussion'], // ['keynotes', 'talks', 'tutorials', 'panelDiscussion']
         registrationHideItems: [], // ['tickets', 'financialAid']
         venueHideItems: [], // ['venueInfo', 'accommodation']
     },


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description
<!--Describe what the change is**-->
Switch on 2024 Tutorials(專業課程) and Talks(一般演講) pages

## Steps to Test This Pull Request
1. Go to path/2024/zh-hant/conference/talks 
2. Go to path/2024/zh-hant/conference/tutorials 
3. Check if they can be entered from navigation bar "Conference/Talks" and "Conference/Tutorials"

## Expected behavior
<!--A clear and concise description of what you expected to happen-->
<img width="514" alt="image" src="https://github.com/pycontw/pycontw-frontend/assets/26858727/b1214441-518e-4a9e-907f-c582ec9b42a1">


## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->
#529 
#528 

