### PR TITLE
fix(dev): json-server does not return correct speech data

### DIFF
--- a/routes.json
+++ b/routes.json
@@ -3,7 +3,7 @@
     "/api/sponsors/jobs/": "/jobs",
     "/api/events/keynotes/": "/keynotes",
     "/api/events/speeches/\\?event_types=:event_type": "/speeches/?event_type=:event_type",
+    "/api/events/speeches/category/:category": "/speeches/?category=:category",
     "/api/events/speeches/:event_type/:id": "/speeches/?event_type=:event_type&id=:id&singular=1",
-    "/api/events/schedule": "/schedules",
-    "/api/events/speeches/category/:category": "/speeches/?category=:category"
+    "/api/events/schedule": "/schedules"
 }


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description

issue: https://github.com/pycontw/pycontw-frontend/pull/550#issuecomment-2202667612

the behavior of how json-server reads the route settings seems to be changed. 

When requesting `/api/events/speeches/category/:category`, the json-server incorrectly matches the route `/api/events/speeches/:event_type/:id` (take `category` as even type, and `:category` as the id). Changing the sequence in routes.json solves this issue.