### PR TITLE
refactor(conference): naming in poster-session 

### DIFF
--- a/components/core/header/nav-bar/NavBar.i18n.js
+++ b/components/core/header/nav-bar/NavBar.i18n.js
@@ -33,8 +33,8 @@ export default genI18nMessages({
         accommodation: 'Accommodation',
         proposalSystemUrl: 'Proposal System',
         codeOfConduct: 'Code of Conduct',
-        posterSession: 'Call for Poster',
-        posterSessions: 'Poster Sessions',
+        cfpPoster: 'Call for Poster',
+        posterSession: 'Poster Session',
     },
     'zh-hant': {
         about: '關於',
@@ -68,7 +68,7 @@ export default genI18nMessages({
         accommodation: '住宿資訊',
         proposalSystemUrl: '投稿系統',
         codeOfConduct: '行為準則',
-        posterSession: '海報募集',
-        posterSessions: '海報環節',
+        cfpPoster: '海報募集',
+        posterSession: '海報環節',
     },
 })

--- a/components/core/header/nav-bar/nav-bar-items.js
+++ b/components/core/header/nav-bar/nav-bar-items.js
@@ -18,7 +18,7 @@ export default Object.freeze({
         { i18nKey: 'talks', value: '/conference/talks' },
         { i18nKey: 'tutorials', value: '/conference/tutorials' },
         { i18nKey: 'panelDiscussion', value: '/conference/panel-discussion' },
-        { i18nKey: 'posterSessions', value: '/conference/poster-sessions' },
+        { i18nKey: 'posterSession', value: '/conference/poster-session' },
     ],
     events: [
         { i18nKey: 'sprints', value: '/events/sprints' },

--- a/i18n/about/history.i18n.js
+++ b/i18n/about/history.i18n.js
@@ -133,7 +133,7 @@ export default genI18nMessages({
                 'Last year, PyCon Taiwan guided attendees back to physical conferences from the virtual world. ' +
                 'In PyCon Taiwan 2024, we’re taking attendees to Kaohsiung! ' +
                 'Drawing inspiration from other Python Conferences worldwide, this year’s program ' +
-                'introduces Poster Sessions to bridge the gap between speakers and attendees. ' +
+                'introduces Poster Session to bridge the gap between speakers and attendees. ' +
                 'We aim to foster closer connections through face-to-face discussions, sparking creativity and exchanging ideas.',
         },
         terms: {

--- a/i18n/about/index.i18n.js
+++ b/i18n/about/index.i18n.js
@@ -33,7 +33,7 @@ export default genI18nMessages({
             'and at the same time to meet many friends from various parties in the exchange activities.',
         activityDetails: [
             'Speeches include: keynote speeches, general speeches, professional courses',
-            'Activities include: sprint, open space, lightning talk, JobFair, Poster Sessions, PyNight',
+            'Activities include: sprint, open space, lightning talk, JobFair, Poster Session, PyNight',
         ],
         moreInfo:
             'If you want to learn more about each event or want to register for the above events, ' +
@@ -69,7 +69,7 @@ export default genI18nMessages({
             '可以說是非常多元有趣，讓你可以從演講中吸取知識的同時，還能在交流活動中結識許多各方好友。',
         activityDetails: [
             '演講包括：主題演講、一般演講、專業課程',
-            '交流活動包括：衝刺開發、開放空間、閃電秀、Poster Sessions、JobFair、PyNight',
+            '交流活動包括：衝刺開發、開放空間、閃電秀、海報環節、JobFair、PyNight',
         ],
         moreInfo:
             '若想要深入了解各活動或是想要報名以上活動，歡迎到議程總覽頁面觀看。',

--- a/i18n/conference/poster-session.i18n.js
+++ b/i18n/conference/poster-session.i18n.js
@@ -26,7 +26,7 @@ export default genI18nMessages({
             we'll host the Poster Session for the first time, aiming to provide a platform for more individuals to share their projects or topics of interest. 
             You are invited to submit a paper on any Python-related topic, which will be exhibited as a poster, enabling you to have direct conversations with attendees.
         `,
-        sessions: [
+        posters: [
             {
                 id: '1',
                 name: 'KK',
@@ -229,7 +229,7 @@ export default genI18nMessages({
             希望可以讓更多人介紹自己的成果或是關注的議題。您可以投稿任何跟 Python 有關的主題，
             屆時將以海報形式展出，然後與會者可與您直接互動。
         `,
-        sessions: [
+        posters: [
             {
                 id: '1',
                 name: 'KK',

--- a/pages/conference/poster-session.vue
+++ b/pages/conference/poster-session.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
-    <div class="poster-sessions">
+    <div class="poster-session">
         <banner>
             <core-h1 :title="$t('title')"></core-h1>
             <i18n path="intro" tag="p" class="intro">
@@ -8,33 +8,31 @@
             </i18n>
         </banner>
         <i18n-page-wrapper class="px-2 sm:px-8 md:px-16 lg:px-32" custom-x>
-            <div class="poster-sessions__container">
+            <div class="poster-session__container">
                 <article
-                    v-for="session in $t('sessions')"
-                    :id="session.id"
-                    :key="session.id"
-                    class="poster-sessions__card"
-                    @click="showModal(session)"
+                    v-for="poster in $t('posters')"
+                    :id="poster.id"
+                    :key="poster.id"
+                    class="poster-session__card"
+                    @click="showModal(poster)"
                 >
                     <div class="mb-6 text-right text-xs">
-                        {{ session.type }}
+                        {{ poster.type }}
                     </div>
                     <div
                         class="line-clamp-5 five-line-height mb-6 text-[#CDCBFF]"
                     >
-                        {{ session.title }}
+                        {{ poster.title }}
                     </div>
                     <div
                         class="mb-2 flex flex-wrap gap-x-1 text-xs text-[#BB75BC]"
                     >
                         <span>
-                            {{ session.name }}
+                            {{ poster.name }}
                         </span>
                         <span>
                             {{
-                                `${session.community && '|'} ${
-                                    session.community
-                                }`
+                                `${poster.community && '|'} ${poster.community}`
                             }}
                         </span>
                     </div>
@@ -42,7 +40,7 @@
                         class="flex flex-1 flex-col items-start justify-end gap-y-1 text-center text-[10px]"
                     >
                         <span
-                            v-for="topic in session.topics"
+                            v-for="topic in poster.topics"
                             :id="topic"
                             :key="topic"
                             class="rounded-md bg-[#BB75BC] p-1 text-[#000]"
@@ -57,19 +55,19 @@
             <modal v-if="isOpened" v-model="isOpened">
                 <div class="flex flex-col items-center space-y-3 p-2">
                     <div class="text-xl text-[#CDCBFF]">
-                        {{ selectedSession.title }}
+                        {{ selectedPoster.title }}
                     </div>
                     <div class="text-center text-sm">
                         <div class="text-[#BB75BC]">
-                            {{ selectedSession.name }}
+                            {{ selectedPoster.name }}
                         </div>
                         <div class="text-[#BB75BC]">
-                            {{ selectedSession.community }}
+                            {{ selectedPoster.community }}
                         </div>
                     </div>
 
                     <div
-                        v-html="$md.render(selectedSession.summary.trim())"
+                        v-html="$md.render(selectedPoster.summary.trim())"
                     ></div>
                 </div>
             </modal>
@@ -85,7 +83,7 @@ import Modal from './_components/modal/Modal'
 
 export default {
     i18n,
-    name: 'PageConferencePosterSessions',
+    name: 'PageConferencePosterSession',
     components: {
         Banner,
         CoreH1,
@@ -95,7 +93,7 @@ export default {
     data() {
         return {
             isOpened: false,
-            selectedSession: {
+            selectedPoster: {
                 id: '1',
                 name: 'KK',
                 type: '社群講',
@@ -108,9 +106,9 @@ export default {
         }
     },
     methods: {
-        showModal(session) {
+        showModal(poster) {
             this.isOpened = true
-            this.selectedSession = session
+            this.selectedPoster = poster
         },
     },
 }
@@ -121,14 +119,14 @@ p.description {
     text-align: unset;
 }
 
-.poster-sessions__container {
+.poster-session__container {
     display: grid;
     justify-content: center;
     gap: 8px;
     grid-template-columns: repeat(auto-fit, 239px);
 }
 
-.poster-sessions {
+.poster-session {
     @apply py-10 md:py-24;
 
     .five-line-height {
@@ -138,7 +136,7 @@ p.description {
     }
 }
 
-.poster-sessions__card {
+.poster-session__card {
     @apply flex cursor-pointer flex-col rounded-3xl bg-[#1f1c3b] p-6;
     border: 1px solid transparent;
 
@@ -156,7 +154,7 @@ p.description {
     }
 }
 
-.poster-sessions .summary-link {
+.poster-session .summary-link {
     text-decoration: underline;
     color: #da8bdc;
 }


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
* **Refactoring**

## Description
Poster Session is a single event with multiple posters at this year's conference, unlike talks and tutorials, which are multiple events each with a specific topic. 
I made some adjustments to ensure the naming in the code fits this context.
