### PR TITLE
fix(poster-session): fix font size on RWD

### DIFF
--- a/pages/conference/poster-session.vue
+++ b/pages/conference/poster-session.vue
@@ -67,6 +67,7 @@
                     </div>
 
                     <div
+                        class="text-sm md:text-lg"
                         v-html="$md.render(selectedPoster.summary.trim())"
                     ></div>
                 </div>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
<!--Describe what the change is**-->
Fix the broken UI in the pop-up poster info.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->
1. Go to path/2024/zh-hant/conference/poster-session
2. Switch to RWD mode with Inspect tools.
3. Click Responsive dorpdown menu choose the small one (iPhoneSE).
4. Click on the poster titled “從台灣走向國際、從源來適你走向開源” and check if the err is still there.
## Expected behavior
<!--A clear and concise description of what you expected to happen-->
text of description of poster-session stay in border when use of RWD model.

## Screenshot
<!--Add any other context or screenshots about the pull request here.-->
![螢幕擷取畫面 2024-08-05 144040](https://github.com/user-attachments/assets/89c7fd05-1394-453f-8840-9b491e5bec19)

