### PR TITLE
refactor(sponsor): non-i18n content adjustment

### DIFF
--- a/i18n/sponsor/index.i18n.js
+++ b/i18n/sponsor/index.i18n.js
@@ -43,10 +43,7 @@ export default genI18nMessages({
         summary:
             'If you are interested in the event, please leave contact information below, ' +
             'and we will provide the sponsorship packages detail to you. Or contact us ' +
-            'directly via {contact} to get any further information.',
-        terms: {
-            contact: 'sponsorship@python.tw',
-        },
+            'directly via sponsorship@python.tw to get any further information.',
         cta: {
             text: 'Application Form',
         },
@@ -96,10 +93,7 @@ export default genI18nMessages({
         ],
         summary:
             '若想了解 PyConTW 2024 完整的贊助方案，歡迎點擊下方按鈕填寫表單留下您的聯絡資料' +
-            '索取贊助書或是直接透過贊助組信箱 {contact} 聯絡我們，讓我們了解貴單位的需求！',
-        terms: {
-            contact: 'sponsorship@python.tw',
-        },
+            '索取贊助書或是直接透過贊助組信箱 sponsorship@python.tw 聯絡我們，讓我們了解貴單位的需求！',
         cta: {
             text: '索取贊助書',
         },

--- a/i18n/sponsor/index.i18n.js
+++ b/i18n/sponsor/index.i18n.js
@@ -43,7 +43,7 @@ export default genI18nMessages({
         summary:
             'If you are interested in the event, please leave contact information below, ' +
             'and we will provide the sponsorship packages detail to you. Or contact us ' +
-            'directly via sponsorship@python.tw to get any further information.',
+            'directly via {contact} to get any further information.',
         cta: {
             text: 'Application Form',
         },
@@ -93,7 +93,7 @@ export default genI18nMessages({
         ],
         summary:
             '若想了解 PyConTW 2024 完整的贊助方案，歡迎點擊下方按鈕填寫表單留下您的聯絡資料' +
-            '索取贊助書或是直接透過贊助組信箱 sponsorship@python.tw 聯絡我們，讓我們了解貴單位的需求！',
+            '索取贊助書或是直接透過贊助組信箱 {contact} 聯絡我們，讓我們了解貴單位的需求！',
         cta: {
             text: '索取贊助書',
         },

--- a/pages/sponsor/index.vue
+++ b/pages/sponsor/index.vue
@@ -52,7 +52,7 @@
                     href="mailto:sponsorship@python.tw"
                     highlight
                     underline
-                    >{{ $t('terms.contact') }}</ext-link
+                    >sponsorship@python.tw</ext-link
                 >
             </template>
         </i18n>


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Refactoring**

## Description
<!--Describe what the change is**-->
Remove content that does not require i18n conversion.

## Steps to Test This Pull Request

Steps to reproduce the behavior:
1.  Into pages/sponsor/index.vue
2.  Check line 54 in index.vue if $t('terms.contact') become sponsorship@python.tw or not
3. Into i18n/sposor/index.i18n.js
4. Check if terms: {contact: 'sponsorship@python.tw', } has been removed from both en-us and zh-hant in index.i18n.js.
5. Into http://localhost:3000/2024/en-us/sponsor 
6. Check if sponsorship@python.tw showed normally or not







