### PR TITLE
feat: test the ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
         strategy:
             matrix:
-                os: [ ubuntu-latest ]
+                os: [ ubuntu-22.04 ]
                 node: [ 14.21.3 ]
 
         steps:


### PR DESCRIPTION
## Description
CI's os is expired.

Error message: This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101v

## Expected behavior
fix the ci function.

## Related Issue
#615 
