### PR TITLE
fix(keynotes): add aspect ratio to keynote photo images

### DIFF
--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -218,6 +218,7 @@ export default {
 
 .keynote__photo img {
     @apply rounded-full object-cover;
+    aspect-ratio: 1 / 1;
     height: 100%;
 }
 


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
* display keynote speaker photos in a proper aspect ratio

## Related Issue
#624 


## Additional context
<!--Add any other context or screenshots about the pull request here.-->
