### PR TITLE
fix(nuxt.config.js): add runtime config for api base url

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -244,6 +244,9 @@ export default {
     },
 
     publicRuntimeConfig: {
+        http: {
+            browserBaseURL: process.env.BASE_URL || DEFAULT_BASE_URL,
+        },
         gtm: {
             id: process.env.GOOGLE_TAG_MANAGER_ID,
         },


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
Updated `nuxt.config.js` to use `publicRuntimeConfig.http.browserBaseURL` for dynamic API base URL injection.

## Steps to reproduce the behavior:
- Navigate to https://staging.pycon.tw/2025/zh-hant/conference/keynotes
- On first load (SSR), the API calls (for keynotes, talks, etc) go to: https://staging.pycon.tw/prs/...
- But after you navigate to another route and then back to /conference/keynotes:
- The client-side code can no longer see process.env.BASE_URL.
- The code falls back to the default (possibly https://tw.pycon.org/prs), not the staging API URL

## Steps to Test This Pull Request
- Set a custom BASE_URL in your environment variables.
- Start the Nuxt app and load a page (SSR).
- Navigate between pages (client-side) and verify that API requests continue to use the correct base URL.

## Additional context
Reference: https://http.nuxtjs.org/api/runtime-config
