### PR TITLE
feat: add Reviewers section to main page layout

### DIFF
--- a/components/reviewers/Reviewers.vue
+++ b/components/reviewers/Reviewers.vue
@@ -14,7 +14,11 @@
                 @click="openModal(member)"
             >
                 <div class="reviewerPhoto">
-                    <img :src="member.photo_url || '/img/staff/default.jpg'" />
+                    <img
+                        :src="
+                            member.photo_url || '@/static/img/staff/default.jpg'
+                        "
+                    />
                 </div>
                 <div class="reviewerName">
                     {{ member.full_name }}
@@ -53,7 +57,7 @@
                         class="selectedReviewerPhoto"
                         :src="
                             selectedReviewer.photo_url ||
-                            '/img/staff/default.jpg'
+                            '@/static/img/staff/default.jpg'
                         "
                         alt="photo"
                     />

--- a/routes.json
+++ b/routes.json
@@ -6,5 +6,5 @@
     "/api/events/speeches/category/:category": "/speeches/?category=:category",
     "/api/events/speeches/:event_type/:id": "/speeches/?event_type=:event_type&id=:id&singular=1",
     "/api/events/schedule": "/schedules",
-    "/api/users": "/reviewers"
+    "/accounts/api/users": "/reviewers"
 }

--- a/store/index.js
+++ b/store/index.js
@@ -100,7 +100,9 @@ export const actions = {
         commit('setRelatedData', relatedList)
     },
     async $getStaffsData({ commit }) {
-        const reviewerList = await this.$http.$get('/api/users/')
+        const reviewerList = await this.$http.$get(
+            '/accounts/api/users?role=Reviewer',
+        )
         commit('setStaffsData', reviewerList)
     },
 }


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
<!--Describe what the change is**-->

Modify API endpoint and photo path concatenation.

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

1. Navigate to the mainpage (/)
2. Scroll down to the Reviewers section
3. Verify that all reviewers are displayed with their avatar and name
4. Click on any reviewer's avatar
5. A modal should appear showing the reviewer's detailed information
6. Click outside the modal or on the close (×) button to dismiss it

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

- The Reviewers section appears correctly at the bottom of the mainpage
- Each reviewer displays their photo and name properly
- Clicking a reviewer opens a modal with their full profile, including photo, name, bio, and available social links
- Modal opens and closes smoothly without errors
- No broken images or JavaScript errors in the console