### PR TITLE
  update(events): change sprint event tag from post-event to warmup

### DIFF
--- a/pages/events/overview.vue
+++ b/pages/events/overview.vue
@@ -54,7 +54,7 @@ export default {
             eventInfos: [
                 {
                     tag: 'sprint',
-                    eventTag: 'post_event',
+                    eventTag: 'warmup',
                     tagColor: 'orange',
                     imgUrl: require('~/static/img/events/overview/sprint.png'),
                     imgAlt: 'Sprint',


### PR DESCRIPTION
## Description

  - Update sprint event classification in events overview page
  - Change eventTag from 'post_event' to 'warmup' to reflect sprint development as a pre-conference activity