### PR TITLE
fix(tabs): add break-all utility to tab styling for better text handling

### DIFF
--- a/components/core/tabs/Tabs.vue
+++ b/components/core/tabs/Tabs.vue
@@ -67,7 +67,7 @@ export default {
 }
 
 .tab {
-    @apply inline-block w-full bg-opacity-0 p-4 text-xs text-black-200 md:text-sm;
+    @apply inline-block w-full break-all bg-opacity-0 p-4 text-xs text-black-200 md:text-sm;
     @apply border-t-2 border-solid border-pink-700;
     line-height: 29px;
     font-size: 16px;


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**

## Description
Add break-all utility to tab styling for better text handling.