### PR TITLE
feat: lazy-loading iframes in keynotes and talks pages

### DIFF
--- a/components/core/embed/Youtube.vue
+++ b/components/core/embed/Youtube.vue
@@ -5,6 +5,7 @@
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowfullscreen
+            loading="lazy"
         >
         </iframe>
     </div>

--- a/components/core/tabs/Tab.vue
+++ b/components/core/tabs/Tab.vue
@@ -14,7 +14,7 @@ export default {
     },
     data() {
         return {
-            isActive: true,
+            isActive: false,
         }
     },
 }

--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -135,12 +135,14 @@
                 <iframe
                     class="speech__slido"
                     :src="data.slido_embed_link"
+                    loading="lazy"
                 ></iframe>
             </tab>
             <tab v-if="!!data.hackmd_embed_link" :title="$t('terms.note')">
                 <iframe
                     class="speech__hackmd"
                     :src="data.hackmd_embed_link"
+                    loading="lazy"
                 ></iframe>
             </tab>
         </tabs>

--- a/pages/conference/keynotes.vue
+++ b/pages/conference/keynotes.vue
@@ -95,6 +95,7 @@
                         <iframe
                             class="keynote__slido"
                             :src="keynote.slido"
+                            loading="lazy"
                         ></iframe>
                     </tab>
                     <tab
@@ -104,6 +105,7 @@
                         <iframe
                             class="keynote__hackmd"
                             :src="keynote.hackmd_embed_link"
+                            loading="lazy"
                         ></iframe>
                     </tab>
                 </tabs>


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

* **Bugfix**


## Description
iframe 加上 `loading='lazy'`，並把 tab 的 `isActive` 預設值改成 `false`，否則 iframe 還是會在進入頁面就載入 (chrome)。

## Related Issue
#641 
