### PR TITLE
fix: remove unnecessary eslint-disable comment in Swal method

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -216,7 +216,6 @@ export default {
         },
         showSwal() {
             return new Swal({
-                // eslint-disable-line
                 title: this.$i18n.t('typhoonInfoTitle'),
                 html: this.$i18n
                     .t('typhoonInfo')


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->
* **Bugfix**

## Description
- Removed an unused `// eslint-disable-line` comment from the `showSwal`

## Steps to Test This Pull Request
- Run `npm run dev`without any exception happens.
