### PR TITLE
移動  Lightning Talk 閃電秀  菜單上 排序

### DIFF
--- a/components/core/header/nav-bar/nav-bar-items.js
+++ b/components/core/header/nav-bar/nav-bar-items.js
@@ -22,9 +22,9 @@ export default Object.freeze({
     ],
     events: [
         { i18nKey: 'sprints', value: '/events/sprints' },
+        { i18nKey: 'lightningTalk', value: '/events/lightning-talk' },
         { i18nKey: 'openSpaces', value: '/events/open-spaces' },
         { i18nKey: 'jobs', value: '/events/jobs' },
-        { i18nKey: 'lightningTalk', value: '/events/lightning-talk' },
     ],
     registration: [
         { i18nKey: 'tickets', value: '/registration/tickets' },


### PR DESCRIPTION
移動後的順序

<img width="191" height="279" alt="image" src="https://github.com/user-attachments/assets/b0c8035b-862d-4ea5-99ef-f61402bb30b7" />
