### PR TITLE
feat: update venue page for PyCon Taiwan 2025

### DIFF
--- a/components/venue/VenueMap.vue
+++ b/components/venue/VenueMap.vue
@@ -1,108 +1,21 @@
 <template>
-    <l-map
-        ref="leafletMap"
-        style="height: 500px"
-        :zoom="zoom"
-        :center="center"
-        :options="options"
-    >
-        <l-tile-layer
-            v-for="tileProvider in tileProviders"
-            :key="tileProvider.name"
-            :name="tileProvider.name"
-            :visible="tileProvider.visible"
-            :url="tileProvider.url"
-            :attribution="tileProvider.attribution"
-            layer-type="base"
-        />
-        <l-control-layers position="bottomright"></l-control-layers>
-        <l-control-zoom position="topright"></l-control-zoom>
-        <l-control
-            position="topright"
-            class="leaflet-bar custom-control rounded-sm"
+    <div class="map-container flex justify-center">
+        <iframe
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3614.701460952581!2d121.55841957523619!3d25.044203537880847!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3442abbf10d06711%3A0x18365043482713a4!2sTaipei%20New%20Horizon%20Building!5e0!3m2!1sen!2sus!4v1754499558330!5m2!1sen!2sus"
+            width="600"
+            height="450"
+            style="border: 0"
+            allowfullscreen=""
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
         >
-            <button
-                class="h-[30px] w-[30px] bg-white leading-[30px]"
-                @click="centerMap"
-            >
-                <img
-                    class="m-auto"
-                    :src="venueButtonUrl"
-                    alt="venue-center-btn"
-                />
-            </button>
-        </l-control>
-        <l-marker :lat-lng="markerLatLng" :icon="icon">
-            <l-tooltip
-                :options="{
-                    offset: [-4, 20],
-                    direction: 'bottom',
-                }"
-                >中央研究院 人文社會科學館</l-tooltip
-            ></l-marker
-        >
-    </l-map>
+        </iframe>
+    </div>
 </template>
 
 <script>
 export default {
     name: 'VenueMap',
-    data() {
-        return {
-            venueButtonUrl: require('@/static/venue-button.png'),
-            currentCenter: [25.040997, 121.611417],
-            options: {
-                zoomControl: false,
-                scrollWheelZoom: false,
-                minZoom: 10,
-            },
-            tileProviders: [
-                {
-                    name: 'Stamen',
-                    visible: false,
-                    attribution:
-                        'Tiles by <a href="https://stamen.com">Stamen Design</a>. Data &copy; <a href="https://openstreetmap.org">OpenStreetMap</a> contributors.',
-                    url: 'http://{s}.sm.mapstack.stamen.com/((toner-background,$fff[@20],$000[hsl-color])[@90],(toner-lines,$fff[@80],$fff[hsl-saturation@20],$502526[hsl-color]),(toner-labels,$fff[@30]))/{z}/{x}/{y}.png',
-                },
-                {
-                    name: 'Transport',
-                    visible: true,
-
-                    attribution:
-                        'Maps &copy; <a href="https://www.thunderforest.com" target="_blank" rel="noopener">Thunderforest</a>, Data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap </a> contributors.',
-                    url: 'https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey=6170aad10dfd42a38d4d8c709a536f38',
-                },
-            ],
-            url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            attribution:
-                '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-            zoom: 16,
-            icon: null,
-            center: [25.040997, 121.611417],
-            markerLatLng: [25.040997, 121.611417],
-        }
-    },
-    mounted() {
-        this.getLeaflet()
-    },
-    methods: {
-        centerMap() {
-            this.$nextTick(() => {
-                this.$refs.leafletMap.mapObject.panTo([25.040997, 121.611417])
-            })
-        },
-        async getLeaflet() {
-            this.L = await import('leaflet')
-            this.icon = this.L.icon({
-                iconUrl: '/snake.png',
-                shadowUrl: '/snake-bg.png',
-                iconSize: [42, 42],
-                iconAnchor: [21, 21],
-                shadowSize: [45, 55],
-                shadowAnchor: [25, 30],
-            })
-        },
-    },
 }
 </script>
 

--- a/i18n/venue/index.i18n.js
+++ b/i18n/venue/index.i18n.js
@@ -8,11 +8,36 @@ export default genI18nMessages({
                 'PyCon Taiwan 2024 will be held at the National Science and Technology Museum (South Complex), with a focus on the latest technology and best practices in Python. The open-source community will bring high-quality speeches and workshops, providing valuable learning and networking opportunities for both novice and experienced Python developers.',
         },
         venueInfo: {
-            name: 'National Science and Technology Museum\n (South Complex)',
-            address: '797 Jiuru 1st Rd. Sanmin District, Kaohsiung City',
+            name: 'Main Conference Venue (09/06-09/07)\nTaipei New Horizon 6F',
+            address:
+                'Address: 6F, No. 88, Yanchang Rd, Xinyi District, Taipei City, Taiwan',
+        },
+        sprintsVenueInfo: {
+            name: 'Sprints Venue (09/05)',
+            address: 'Address: TBD',
         },
         venueMap: {
             title: 'Venue Map',
+        },
+        howToGetThere: {
+            title: 'How to Get There',
+        },
+        transportation: {
+            mrt: '🚇 By MRT (Taipei Metro)',
+            bus: '🚌 By Bus',
+            mrtStation1:
+                'Sun Yat-Sen Memorial Hall Station (Blue Line, Exit 5)',
+            mrtDetail1:
+                "Take Exit 5, turn right onto Guangfu South Road, then turn right onto Yanchang Road. It's about a 500-meter walk (approx. 7 minutes).",
+            mrtStation2: 'Taipei City Hall Station (Blue Line, Exit 1)',
+            mrtDetail2:
+                "Take Exit 1 and walk straight along Songgao Road toward Guangfu South Road. It's about a 400-meter walk (approx. 5 minutes).",
+            busStation1: 'Sun Yat-Sen Memorial Hall Station (Guangfu Stop)',
+            busRoutes1:
+                'Bus routes: 204, 278, 278 Shuttle, 282, 288, 672, Chengde Main Line',
+            busStation2: 'United Daily News Stop',
+            busRoutes2:
+                "Bus routes: 202, 212, 212 Night Bus, 212 Express, 232 Express, 240 Express, 270, 299, 600, Ren'ai Main Line, Zhongxiao Main Line",
         },
         transMode: {
             car: 'By Car',
@@ -121,11 +146,33 @@ export default genI18nMessages({
                 'PyCon Taiwan 2024 將在國立科學工藝博物館南館舉辦，聚焦於 Python 的最新技術和最佳實踐，讓開源社群帶來高品質的演講和工作坊，無論您是 Python 的新手還是資深開發人員，都能在這裡找到有價值的學習和交流機會。',
         },
         venueInfo: {
-            name: '國立科學工藝博物館\n南館',
-            address: '高雄市三民區九如一路 797 號',
+            name: '主要研討會場地 (09/06-09/07)\n台北文創六樓',
+            address: '地址: 台北市信義區菸廠路 88 號 6 樓（誠品生活松菸店內）',
+        },
+        sprintsVenueInfo: {
+            name: 'Sprints 場地 (09/05)',
+            address: '地址: TBD',
         },
         venueMap: {
             title: '會場地圖',
+        },
+        howToGetThere: {
+            title: '交通指引',
+        },
+        transportation: {
+            mrt: '🚇 捷運 | By MRT (Taipei Metro)',
+            bus: '🚌 公車 | By Bus',
+            mrtStation1: '捷運國父紀念館站（板南線，5號出口）',
+            mrtDetail1:
+                '從 5 號出口出站後，右轉光復南路，再右轉菸廠路，步行約 500 公尺，約 7 分鐘。',
+            mrtStation2: '捷運市政府站（板南線，1號出口）',
+            mrtDetail2:
+                '從 1 號出口出站後，沿松高路直行，步行約 400 公尺，約 5 分鐘即可抵達。',
+            busStation1: '國父紀念館站（光復南路）',
+            busRoutes1: '公車路線：204、278、278區、282、288、672、承德幹線',
+            busStation2: '聯合報站',
+            busRoutes2:
+                '公車路線：202、212、212夜、212直、232快、240直、270、299、600、仁愛幹線、忠孝幹線',
         },
         transMode: {
             car: '自行開車',

--- a/pages/venue/index.vue
+++ b/pages/venue/index.vue
@@ -9,27 +9,6 @@
         <h3 class="venue-address">
             {{ $t('venueInfo.address') }}
         </h3>
-        <div class="transportsModesTabs mb-8 flex w-full justify-center">
-            <VenueTabs v-model="selectedTransModeIndex">
-                <VenueTab
-                    v-for="(transMode, index) in transModes"
-                    :key="transMode.value"
-                    :index="index"
-                >
-                    {{ transMode.label }}
-                </VenueTab>
-            </VenueTabs>
-        </div>
-        <div class="detailWrapper">
-            <VenueDriveTab v-if="selectedTransModeIndex === 0"></VenueDriveTab>
-            <VenuePublicTransporterTab
-                v-if="selectedTransModeIndex === 1"
-            ></VenuePublicTransporterTab>
-
-            <VenueShuttleServiceTab
-                v-if="selectedTransModeIndex === 2"
-            ></VenueShuttleServiceTab>
-        </div>
         <client-only v-if="showVenueMap">
             <core-h1
                 class="venue-title whitespace-pre-line pt-20 text-center"
@@ -39,6 +18,83 @@
             </core-h1>
             <VenueMap class=""></VenueMap>
         </client-only>
+        <core-h1
+            class="venue-title whitespace-pre-line pt-6 text-center"
+            :title="$t('howToGetThere.title')"
+            center
+        >
+        </core-h1>
+        <div class="how-to-get-there-content mx-auto max-w-4xl px-4 text-left">
+            <div class="transportation-info">
+                <div class="mb-8">
+                    <h3 class="mb-2 text-2xl font-bold">
+                        {{ $t('transportation.mrt') }}
+                    </h3>
+                    <div class="space-y-6">
+                        <div class="ml-4">
+                            <div
+                                class="mb-2 text-lg font-semibold text-gray-200"
+                            >
+                                <span class="text-sm">•</span>
+                                {{ $t('transportation.mrtStation1') }}
+                            </div>
+                            <div class="ml-8 text-base text-gray-200">
+                                {{ $t('transportation.mrtDetail1') }}
+                            </div>
+                        </div>
+                        <div class="ml-4">
+                            <div
+                                class="mb-2 text-lg font-semibold text-gray-200"
+                            >
+                                <span class="text-sm">•</span>
+                                {{ $t('transportation.mrtStation2') }}
+                            </div>
+                            <div class="ml-8 text-base text-gray-200">
+                                {{ $t('transportation.mrtDetail2') }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div>
+                    <h3 class="mb-2 text-2xl font-bold">
+                        {{ $t('transportation.bus') }}
+                    </h3>
+                    <div class="space-y-6">
+                        <div class="ml-4">
+                            <div
+                                class="mb-2 text-lg font-semibold text-gray-200"
+                            >
+                                <span class="text-sm">•</span>
+                                {{ $t('transportation.busStation1') }}
+                            </div>
+                            <div class="ml-8 text-base text-gray-200">
+                                {{ $t('transportation.busRoutes1') }}
+                            </div>
+                        </div>
+                        <div class="ml-4">
+                            <div
+                                class="mb-2 text-lg font-semibold text-gray-200"
+                            >
+                                <span class="text-sm">•</span>
+                                {{ $t('transportation.busStation2') }}
+                            </div>
+                            <div class="ml-8 text-base text-gray-200">
+                                {{ $t('transportation.busRoutes2') }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <core-h1
+            class="venue-title whitespace-pre-line pt-20 text-center"
+            :title="$t('sprintsVenueInfo.name')"
+            center
+        >
+        </core-h1>
+        <h3 class="venue-address">
+            {{ $t('sprintsVenueInfo.address') }}
+        </h3>
     </i18n-page-wrapper>
 </template>
 
@@ -46,11 +102,6 @@
 import I18nPageWrapper from '@/components/core/i18n/PageWrapper'
 import CoreH1 from '@/components/core/titles/H1'
 import i18n from '@/i18n/venue/index.i18n'
-import VenueTabs from '@/components/venue/VenueTabs.vue'
-import VenueTab from '@/components/venue/VenueTab.vue'
-import VenuePublicTransporterTab from '@/components/venue/VenuePublicTransporterTab.vue'
-import VenueDriveTab from '@/components/venue/VenueDriveTab.vue'
-import VenueShuttleServiceTab from '@/components/venue/VenueShuttleServiceTab.vue'
 // import VenueMap from '@/components/venue/VenueMap.vue'
 export default {
     i18n,
@@ -58,31 +109,11 @@ export default {
     components: {
         I18nPageWrapper,
         CoreH1,
-        VenueTabs,
-        VenueTab,
-        VenuePublicTransporterTab,
-        VenueDriveTab,
-        VenueShuttleServiceTab,
         VenueMap: () => import('@/components/venue/VenueMap.vue'),
     },
     data() {
         return {
-            selectedTransModeIndex: 0,
-            showVenueMap: false,
-            transModes: [
-                {
-                    label: this.$t('transMode.car'),
-                    value: 'car',
-                },
-                {
-                    label: this.$t('transMode.publicTransport'),
-                    value: 'publicTransport',
-                },
-                // {
-                //     label: this.$t('transMode.shuttleService'),
-                //     value: 'shuttleService',
-                // },
-            ],
+            showVenueMap: true,
         }
     },
     head() {
@@ -115,6 +146,6 @@ export default {
 css priority for h3
 */
 .venue-address {
-    @apply m-0 pt-6 text-center text-base font-normal;
+    @apply m-0 pt-6 text-center text-lg font-normal;
 }
 </style>

--- a/store/index.js
+++ b/store/index.js
@@ -23,9 +23,9 @@ export const state = () => ({
         showIndexSponsorSection: true,
         showProposalSystemPage: true,
         showRegistrationPage: true,
-        showSpeakingPage: true,
+        showSpeakingPage: false,
         showSponsorPage: true,
-        showVenuePage: false,
+        showVenuePage: true,
         aboutHideItems: ['apacCommunity'], // ['pycontw', 'apacCommunity', 'history', 'community', 'codeOfConduct']
         conferenceHideItems: [
             // 'keynotes',
@@ -37,7 +37,8 @@ export const state = () => ({
         eventsHideItems: [], // ['sprints', 'openSpaces', 'jobs']
 
         registrationHideItems: [], // ['tickets', 'financialAid']
-        venueHideItems: ['venueInfo', 'accommodation'], // ['venueInfo', 'accommodation']
+        venueHideItems: ['accommodation'],
+        // ['venueInfo', 'accommodation']
     },
 })
 


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description

- Update venue location from Kaohsiung to Taipei New Horizon
- Replace complex Leaflet map with simple Google Maps iframe
- Add comprehensive bilingual transportation guide with MRT and bus options
- Include Sprints venue information (TBD)
- Remove unused transport mode components and tabs
- Enable venue page in navigation
- Disable speaking page (CFP) in navigation
- Improve typography and spacing consistency


## Expected behavior
<img width="3248" height="2112" alt="CleanShot 2025-08-07 at 02 19 48@2x" src="https://github.com/user-attachments/assets/11960b5f-ac46-44c6-9828-da1fa7ef0039" />

## Related Issue
#658 

