### PR TITLE
fix: add CSS grid support for room-3-r0-all schedule events

### DIFF
--- a/components/schedule/ScheduleGrid.vue
+++ b/components/schedule/ScheduleGrid.vue
@@ -132,6 +132,10 @@ export default {
     grid-column: room-4-r0 / room-81-spt-os;
 }
 
+.day1.scheduleTable .scheduleEvent.room-3-r0-all {
+    grid-column: room-4-r0 / room-81-spt-os;
+}
+
 .day2.scheduleRooms,
 .day2.scheduleTable {
     grid-gap: 12px;
@@ -180,6 +184,10 @@ export default {
 }
 
 .day2.scheduleTable .scheduleEvent.room-2-all {
+    grid-column: room-4-r0 / room-81-spt-os;
+}
+
+.day2.scheduleTable .scheduleEvent.room-3-r0-all {
     grid-column: room-4-r0 / room-81-spt-os;
 }
 </style>

--- a/components/schedule/ScheduleRoom.vue
+++ b/components/schedule/ScheduleRoom.vue
@@ -25,6 +25,8 @@ export default {
     computed: {
         name() {
             return {
+                '2-all': '',
+                '3-r0-all': 'All Rooms',
                 '4-r0': 'R0',
                 '5-r1': 'R1',
                 '6-r2': 'R2',


### PR DESCRIPTION
## Types of changes

* **Bugfix**

## Description
- Add room labels for 2-all (empty) and 3-r0-all (All Rooms) in ScheduleRoom component
- Add CSS grid-column rules for room-3-r0-all to span R0-R4 rooms consistently with room-2-all
- Ensure cross-room events display properly across both day1 and day2 schedules
- Fix missing room label display for registration and welcome events

