### PR TITLE
feat(conference): add new room mappings for additional venues

### DIFF
--- a/components/events/SpeechCard.vue
+++ b/components/events/SpeechCard.vue
@@ -78,6 +78,9 @@ export default {
                 '6-r2': 'R2',
                 '1-r3': 'R3',
                 '7-r4': 'R4',
+                '81-spt-os': 'Sprint / OST',
+                '82-tutorial': 'Tutorial',
+                '83-yi-ps': 'Young / Post',
             },
             levelBgColorMapping: {
                 EXPERIENCED: '#ca7795',

--- a/pages/conference/_eventType/_id.vue
+++ b/pages/conference/_eventType/_id.vue
@@ -215,6 +215,10 @@ export default {
                 '5-r1': 'R1',
                 '6-r2': 'R2',
                 '1-r3': 'R3',
+                '7-r4': 'R4',
+                '81-spt-os': 'Sprint / OST',
+                '82-tutorial': 'Tutorial',
+                '83-yi-ps': 'Young / Post',
             },
         }
     },


### PR DESCRIPTION
## Types of changes
<!--Please remove the types that does not apply to this change-->

* **New feature**

## Description

Add support for 4 new room locations to prevent "TBA" display:
- 7-r4: R4
- 81-spt-os: Sprint / OST
- 82-tutorial: Tutorial
- 83-yi-ps: Young / Post

Updated locationMapping in:
- pages/conference/_eventType/_id.vue (talk details page)
- components/events/SpeechCard.vue (speech cards)

## Additional context
<img width="3248" height="2112" alt="CleanShot 2025-08-27 at 04 10 35@2x" src="https://github.com/user-attachments/assets/560c335b-8446-4d14-ace8-2c70b722049b" />
