### PR TITLE
fix: expand `ScheduleBlock` link click area

### DIFF
--- a/components/schedule/ScheduleBlock.vue
+++ b/components/schedule/ScheduleBlock.vue
@@ -4,6 +4,7 @@
             v-if="!!to"
             :to="to"
             customized
+            class="block h-full w-full"
             @mouseenter="setHoveringState"
             @mouseleave="removeHoveringState"
         >


### PR DESCRIPTION
## Types of changes

* **Bugfix**

## Description

Set `locale-link` from `ScheduleBlock` to fill the parent size.

## Steps to Test This Pull Request

1. Go `/2025/zh-hant/conference/schedule` (on desktop)
2. Click on the empty area of the schedule event block

## Expected behavior

Able to navigate

https://github.com/user-attachments/assets/77f5301b-c631-4a97-987e-5f4270541101

## Related Issue

Fixed #711