### PR TITLE
fix: hide empty `ScheduleRoom` component

### DIFF
--- a/components/schedule/ScheduleRoom.vue
+++ b/components/schedule/ScheduleRoom.vue
@@ -1,5 +1,6 @@
 <template>
     <schedule-block
+        v-if="name"
         class="scheduleRoom whitespace-nowrap font-semibold"
         :mini="inline"
         :padding-x="paddingX"


### PR DESCRIPTION
## Types of changes

* **Bugfix**

## Description

Hide empty `ScheduleRoom` component when `name` is empty.

## Steps to Test This Pull Request

1. Go `/zh-hant/conference/schedule` (with mobile viewport)
2. Scroll to registration & Breakfast

## Expected behavior

The top-left empty circle is hidden.

### Before

<img width="634" height="454" alt="empty_circle" src="https://github.com/user-attachments/assets/37e720e0-5aab-4598-820f-5107454e6bc0" />

### After

<img width="594" height="245" alt="截圖 2025-09-04 03 13 11" src="https://github.com/user-attachments/assets/deba647f-a143-4047-8784-d2acf7c6dc78" />

## Related Issue

Fixed #713