### PR TITLE
feat: support room id expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run linter 👀
         run: pnpm run lint
+
+      - name: Run unit tests 🧪
+        run: pnpm test

--- a/app/composables/conferenceSchedule.ts
+++ b/app/composables/conferenceSchedule.ts
@@ -1,22 +1,26 @@
 import type { ScheduleApiDay, ScheduleApiSlot } from '~/types/schedule'
 
 const ROOMS: Record<string, RoomMeta> = {
-  '4-r0': { label: 'R0', col: 1 },
-  '5-r1': { label: 'R1', col: 2 },
-  '6-r2': { label: 'R2', col: 3 },
-  '1-r3': { label: 'R3', col: 4 },
+  '4-r0': { expId: 'r0', label: 'R0', col: 1 },
+  '5-r1': { expId: 'r1', label: 'R1', col: 2 },
+  '6-r2': { expId: 'r2', label: 'R2', col: 3 },
+  '1-r3': { expId: 'r3', label: 'R3', col: 4 },
   '81-spt-os': { label: { en_us: 'Open Space', zh_hant: '開放空間' }, col: 5 },
   '83-yi-ps': { label: { en_us: 'Poster Session', zh_hant: '海報展' }, col: 6 },
   '3-r0-all': { col: { start: 1, span: 4 } },
   '2-all': { col: { start: 1, span: 4 } },
+  // '=custom': { col: [{ start: 1, span: 2 }, 3] },
 
-  // custom locations
-  'r0,r1,r2': { col: { start: 1, span: 3 } },
+  // room expressions examples:
+  // '=r0~r2': { col: { start: 1, span: 3 } },
+  // '=r1,r2': { col: [2, 3] },
+  // '=r1,r2~r3': { col: [2, { start: 3, span: 2 }] },
 }
 
 interface Column { start: number, span: number }
 
 interface RoomMeta {
+  expId?: string
   label?: MaybeLocalizedText
   col: number | Column | (number | Column)[]
 }

--- a/app/composables/conferenceSchedule.ts
+++ b/app/composables/conferenceSchedule.ts
@@ -13,12 +13,6 @@ const ROOMS: Record<string, RoomMeta> = {
   '83-yi-ps': { label: { en_us: 'Poster Session', zh_hant: '海報展' }, col: 6 },
   '3-r0-all': { col: { start: 1, span: 4 } },
   '2-all': { col: { start: 1, span: 4 } },
-  // '=custom': { col: [{ start: 1, span: 2 }, 3] },
-
-  // room expressions examples:
-  // '=r0~r2': { col: { start: 1, span: 3 } },
-  // '=r1,r2': { col: [2, 3] },
-  // '=r1,r2~r3': { col: [2, { start: 3, span: 2 }] },
 }
 
 interface RoomMeta extends ExpressionRoomMeta {

--- a/app/composables/conferenceSchedule.ts
+++ b/app/composables/conferenceSchedule.ts
@@ -1,4 +1,8 @@
+import type { ExpressionRoomMeta } from '../utils/conferenceScheduleRooms.ts'
+import type { MaybeLocalizedText } from '../utils/locale.ts'
 import type { ScheduleApiDay, ScheduleApiSlot } from '~/types/schedule'
+import { resolveRoomColumns } from '../utils/conferenceScheduleRooms.ts'
+import { formatMinute, getMinuteOfDay } from '../utils/datetime.ts'
 
 const ROOMS: Record<string, RoomMeta> = {
   '4-r0': { expId: 'r0', label: 'R0', col: 1 },
@@ -17,12 +21,8 @@ const ROOMS: Record<string, RoomMeta> = {
   // '=r1,r2~r3': { col: [2, { start: 3, span: 2 }] },
 }
 
-interface Column { start: number, span: number }
-
-interface RoomMeta {
-  expId?: string
+interface RoomMeta extends ExpressionRoomMeta {
   label?: MaybeLocalizedText
-  col: number | Column | (number | Column)[]
 }
 
 interface BaseScheduleSession extends ScheduleApiSlot {
@@ -76,18 +76,21 @@ function toBaseSession(slot: ScheduleApiSlot, room: ScheduleRoomView): BaseSched
   }
 }
 
-function normalizeColumns(cols: RoomMeta['col']): Column[] {
-  return (Array.isArray(cols) ? cols : [cols])
-    .map(col => (typeof col === 'number') ? { start: col, span: 1 } : col)
-}
-
-export function resolveRoomLabel(roomId: string) {
+export function resolveRoomLabel(roomId: string): MaybeLocalizedText {
   return ROOMS[roomId]?.label ?? roomId
 }
 
 export function normalizeConferenceScheduleDays(day: ScheduleApiDay): ScheduleDayView {
-  const roomGroups = Object.entries(ROOMS).map(([roomId, roomMeta]) => {
-    const columns = normalizeColumns(roomMeta.col)
+  const roomIds = new Set([...Object.keys(ROOMS), ...day.rooms, ...Object.keys(day.slots)])
+  const roomGroups = [...roomIds].flatMap((roomId) => {
+    const columns = resolveRoomColumns(roomId, ROOMS)
+
+    if (!columns) {
+      return []
+    }
+
+    const roomMeta = ROOMS[roomId]
+
     return {
       roomId,
       rooms: columns.map(({ start, span }, columnIndex): ScheduleRoomView => ({
@@ -95,7 +98,7 @@ export function normalizeConferenceScheduleDays(day: ScheduleApiDay): ScheduleDa
         placementId: columns.length === 1 ? roomId : `${roomId}:${columnIndex}`,
         gridColumnStart: start,
         gridColumnSpan: span,
-        label: roomMeta.label,
+        label: roomMeta?.label,
       })),
     }
   })

--- a/app/utils/conferenceScheduleRooms.ts
+++ b/app/utils/conferenceScheduleRooms.ts
@@ -27,7 +27,7 @@ function getExpressionRooms<T extends ExpressionRoomMeta>(rooms: Readonly<Record
   return expressionRooms
 }
 
-function resolveRangeColumns(from: ExpressionRoomMeta, to: ExpressionRoomMeta): ScheduleColumn | undefined {
+function resolveRangeColumns(from: ExpressionRoomMeta, to: ExpressionRoomMeta): ScheduleColumn[] | undefined {
   const fromColumns = normalizeColumns(from.col)
   const toColumns = normalizeColumns(to.col)
 
@@ -35,11 +35,33 @@ function resolveRangeColumns(from: ExpressionRoomMeta, to: ExpressionRoomMeta): 
     return undefined
   }
 
-  const boundaryColumns = [...fromColumns, ...toColumns]
-  const start = Math.min(...boundaryColumns.map(column => column.start))
-  const end = Math.max(...boundaryColumns.map(column => column.start + column.span))
+  const columns: ScheduleColumn[] = []
+  const columnCount = Math.max(fromColumns.length, toColumns.length)
 
-  return { start, span: end - start }
+  for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+    const fromColumn = fromColumns[columnIndex]
+    const toColumn = toColumns[columnIndex]
+
+    if (!fromColumn) {
+      if (toColumn) {
+        columns.push(toColumn)
+      }
+
+      continue
+    }
+
+    if (!toColumn) {
+      columns.push(fromColumn)
+      continue
+    }
+
+    const start = Math.min(fromColumn.start, toColumn.start)
+    const end = Math.max(fromColumn.start + fromColumn.span, toColumn.start + toColumn.span)
+
+    columns.push({ start, span: end - start })
+  }
+
+  return columns
 }
 
 export function resolveRoomColumns<T extends ExpressionRoomMeta>(
@@ -90,13 +112,13 @@ export function resolveRoomColumns<T extends ExpressionRoomMeta>(
       return undefined
     }
 
-    const rangeColumn = resolveRangeColumns(from, to)
+    const rangeColumns = resolveRangeColumns(from, to)
 
-    if (!rangeColumn) {
+    if (!rangeColumns) {
       return undefined
     }
 
-    columns.push(rangeColumn)
+    columns.push(...rangeColumns)
   }
 
   return columns.length > 0 ? columns : undefined

--- a/app/utils/conferenceScheduleRooms.ts
+++ b/app/utils/conferenceScheduleRooms.ts
@@ -1,0 +1,103 @@
+export interface ScheduleColumn {
+  start: number
+  span: number
+}
+
+export type ScheduleColumnInput = number | ScheduleColumn | (number | ScheduleColumn)[]
+
+export interface ExpressionRoomMeta {
+  expId?: string
+  col: ScheduleColumnInput
+}
+
+function normalizeColumns(cols: ScheduleColumnInput): ScheduleColumn[] {
+  return (Array.isArray(cols) ? cols : [cols])
+    .map(col => typeof col === 'number' ? { start: col, span: 1 } : col)
+}
+
+function getExpressionRooms<T extends ExpressionRoomMeta>(rooms: Readonly<Record<string, T>>): Map<string, T> {
+  const expressionRooms = new Map<string, T>()
+
+  for (const room of Object.values(rooms)) {
+    if (room.expId && !expressionRooms.has(room.expId)) {
+      expressionRooms.set(room.expId, room)
+    }
+  }
+
+  return expressionRooms
+}
+
+function resolveRangeColumns(from: ExpressionRoomMeta, to: ExpressionRoomMeta): ScheduleColumn | undefined {
+  const fromColumns = normalizeColumns(from.col)
+  const toColumns = normalizeColumns(to.col)
+
+  if (fromColumns.length === 0 || toColumns.length === 0) {
+    return undefined
+  }
+
+  const boundaryColumns = [...fromColumns, ...toColumns]
+  const start = Math.min(...boundaryColumns.map(column => column.start))
+  const end = Math.max(...boundaryColumns.map(column => column.start + column.span))
+
+  return { start, span: end - start }
+}
+
+export function resolveRoomColumns<T extends ExpressionRoomMeta>(
+  roomId: string,
+  rooms: Readonly<Record<string, T>>,
+): ScheduleColumn[] | undefined {
+  const room = Object.hasOwn(rooms, roomId) ? rooms[roomId] : undefined
+
+  if (room) {
+    return normalizeColumns(room.col)
+  }
+
+  if (!roomId.startsWith('=')) {
+    return undefined
+  }
+
+  const expressionRooms = getExpressionRooms(rooms)
+  const columns: ScheduleColumn[] = []
+
+  for (const part of roomId.slice(1).split(',')) {
+    const range = part.split('~').map(expId => expId.trim())
+
+    if (range.length === 1) {
+      const expressionRoom = expressionRooms.get(range[0] ?? '')
+
+      if (!expressionRoom) {
+        return undefined
+      }
+
+      const expressionColumns = normalizeColumns(expressionRoom.col)
+
+      if (expressionColumns.length === 0) {
+        return undefined
+      }
+
+      columns.push(...expressionColumns)
+      continue
+    }
+
+    if (range.length !== 2 || !range[0] || !range[1]) {
+      return undefined
+    }
+
+    const from = expressionRooms.get(range[0])
+    const to = expressionRooms.get(range[1])
+
+    if (!from || !to) {
+      return undefined
+    }
+
+    const rangeColumn = resolveRangeColumns(from, to)
+
+    if (!rangeColumn) {
+      return undefined
+    }
+
+    columns.push(rangeColumn)
+  }
+
+  return columns.length > 0 ? columns : undefined
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
+    "test": "vitest run",
     "lint": "eslint .",
     "mock-server": "pnpm -F pycontw-mock-server json-server"
   },
@@ -34,6 +35,7 @@
     "@types/node": "^25.9.5",
     "concurrently": "^10.0.5",
     "eslint": "^10.8.1",
+    "vitest": "^4.1.10",
     "zod": "^4.4.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^9.3.0
-        version: 9.3.0(@typescript-eslint/typescript-estree@8.67.0(supports-color@10.2.2)(typescript@5.9.3))(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-declaration-location@1.0.7(typescript@5.9.3))(typescript@5.9.3)
+        version: 9.3.0(@typescript-eslint/typescript-estree@8.67.0(supports-color@10.2.2)(typescript@5.9.3))(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-declaration-location@1.0.7(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))
       '@iconify-json/lucide':
         specifier: ^1.2.123
         version: 1.2.123
@@ -63,6 +63,9 @@ importers:
       eslint:
         specifier: ^10.8.1
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -2544,8 +2547,14 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -2737,6 +2746,35 @@ packages:
         optional: true
       vitest:
         optional: true
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2993,6 +3031,10 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -3179,6 +3221,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3967,6 +4013,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-urlrewrite@1.4.0:
     resolution: {integrity: sha512-PI5h8JuzoweS26vFizwQl6UTF25CAHSggNv0J25Dn/IKZscJHWZzPrI5z2Y2jgOzIaw2qh8l6+/jUcig23Z2SA==}
@@ -6037,6 +6087,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -6115,6 +6168,9 @@ packages:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -6264,6 +6320,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -6275,6 +6334,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-buffer@1.2.2:
     resolution: {integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==}
@@ -6768,6 +6831,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -6871,6 +6975,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -7010,7 +7119,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/eslint-config@9.3.0(@typescript-eslint/typescript-estree@8.67.0(supports-color@10.2.2)(typescript@5.9.3))(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-declaration-location@1.0.7(typescript@5.9.3))(typescript@5.9.3)':
+  '@antfu/eslint-config@9.3.0(@typescript-eslint/typescript-estree@8.67.0(supports-color@10.2.2)(typescript@5.9.3))(@typescript-eslint/utils@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(@vue/compiler-sfc@3.5.41)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(ts-declaration-location@1.0.7(typescript@5.9.3))(typescript@5.9.3)(vitest@4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))':
     dependencies:
       '@antfu/install-pkg': 2.0.1
       '@clack/prompts': 1.7.0
@@ -7020,7 +7129,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.10.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
+      '@vitest/eslint-plugin': 1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)(vitest@4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))
       ansis: 4.3.1
       cac: 7.0.0
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
@@ -8605,7 +8714,7 @@ snapshots:
       - vue
       - webpack
 
-  '@nuxt/vite-builder@4.5.2(593d9ec49f864dcb677376f362e960e5)':
+  '@nuxt/vite-builder@4.5.2(3d81d2dadee4a7fd1954a01a150b3636)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.4)(rollup@4.61.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
@@ -8633,7 +8742,6 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unenv: 2.0.0-rc.24
-      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.4)(rollup@4.61.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
       vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
       vite-plugin-checker: 0.14.5(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(optionator@0.9.4)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
@@ -8645,11 +8753,8 @@ snapshots:
       rollup-plugin-visualizer: 7.0.1(rolldown@1.2.4)(rollup@4.61.0)
     transitivePeerDependencies:
       - '@biomejs/biome'
-      - '@farmfe/core'
-      - '@rspack/core'
       - '@types/node'
       - '@vitejs/devtools'
-      - bun-types-no-globals
       - esbuild
       - eslint
       - less
@@ -8659,7 +8764,6 @@ snapshots:
       - optionator
       - oxc-parser
       - oxlint
-      - rollup
       - sass
       - sass-embedded
       - stylelint
@@ -8669,9 +8773,8 @@ snapshots:
       - terser
       - tsx
       - typescript
-      - unloader
+      - unplugin
       - vue-tsc
-      - webpack
       - yaml
 
   '@nuxtjs/color-mode@4.0.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.4)(rollup@4.61.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))':
@@ -9692,9 +9795,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -9913,7 +10023,7 @@ snapshots:
       vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
       vue: 3.5.41(typescript@5.9.3)
 
-  '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)':
+  '@vitest/eslint-plugin@1.6.27(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)(vitest@4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
@@ -9921,8 +10031,50 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3))(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@5.9.3)
       typescript: 5.9.3
+      vitest: 4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -10216,6 +10368,8 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.8
@@ -10406,6 +10560,8 @@ snapshots:
   caniuse-lite@1.0.30001809: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -11277,6 +11433,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   express-urlrewrite@1.4.0(supports-color@10.2.2):
     dependencies:
@@ -12964,7 +13122,7 @@ snapshots:
       '@nuxt/nitro-server': 4.5.2(b917f4ecc3735ead0ff5dcc82ff11506)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.4)(rollup@4.61.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(593d9ec49f864dcb677376f362e960e5)
+      '@nuxt/vite-builder': 4.5.2(3d81d2dadee4a7fd1954a01a150b3636)
       '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.0)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.4)(rollup@4.61.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -14102,6 +14260,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -14183,6 +14343,8 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   srvx@0.11.22: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -14353,6 +14515,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -14361,6 +14525,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-buffer@1.2.2:
     dependencies:
@@ -14845,6 +15011,33 @@ snapshots:
       terser: 5.46.1
       yaml: 2.9.0
 
+  vitest@4.1.10(@types/node@25.9.5)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.0.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@25.9.5)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.46.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.5
+    transitivePeerDependencies:
+      - msw
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.3.2:
@@ -14965,6 +15158,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/tests/conferenceScheduleRooms.test.ts
+++ b/tests/conferenceScheduleRooms.test.ts
@@ -9,6 +9,8 @@ const rooms = {
   'room-r1': { expId: 'r1', col: 2 },
   'room-r2': { expId: 'r2', col: 3 },
   'room-r3': { expId: 'r3', col: 4 },
+  'room-r3r5': { expId: 'r3r5', col: [4, 6] },
+  'room-r4r6': { expId: 'r4r6', col: [5, 7] },
   'room-without-exp-id': { col: 5 },
   'room-foo': { expId: 'foo', col: 6 },
   'empty-room': { expId: 'empty', col: [] },
@@ -49,6 +51,22 @@ describe('resolveRoomColumns', () => {
     expect(resolveRoomColumns('=r1,r2~r3', rooms)).toEqual([
       { start: 2, span: 1 },
       { start: 3, span: 2 },
+    ])
+  })
+
+  it('resolves expressions whose rooms have multiple columns', () => {
+    expect(resolveRoomColumns('=r0,r3r5', rooms)).toEqual([
+      { start: 1, span: 1 },
+      { start: 4, span: 1 },
+      { start: 6, span: 1 },
+    ])
+    expect(resolveRoomColumns('=r0~r3r5', rooms)).toEqual([
+      { start: 1, span: 4 },
+      { start: 6, span: 1 },
+    ])
+    expect(resolveRoomColumns('=r3r5~r4r6', rooms)).toEqual([
+      { start: 4, span: 2 },
+      { start: 6, span: 2 },
     ])
   })
 

--- a/tests/conferenceScheduleRooms.test.ts
+++ b/tests/conferenceScheduleRooms.test.ts
@@ -1,0 +1,116 @@
+import type { ScheduleApiDay, ScheduleApiSlot } from '../app/types/schedule.ts'
+import type { ExpressionRoomMeta } from '../app/utils/conferenceScheduleRooms.ts'
+import { describe, expect, it } from 'vitest'
+import { normalizeConferenceScheduleDays } from '../app/composables/conferenceSchedule.ts'
+import { resolveRoomColumns } from '../app/utils/conferenceScheduleRooms.ts'
+
+const rooms = {
+  'room-r0': { expId: 'r0', col: 1 },
+  'room-r1': { expId: 'r1', col: 2 },
+  'room-r2': { expId: 'r2', col: 3 },
+  'room-r3': { expId: 'r3', col: 4 },
+  'room-without-exp-id': { col: 5 },
+  'room-foo': { expId: 'foo', col: 6 },
+  'empty-room': { expId: 'empty', col: [] },
+  '=foo': { col: [{ start: 1, span: 2 }, 3] },
+} satisfies Record<string, ExpressionRoomMeta>
+
+const slot = {
+  event_id: 1,
+  event_type: 'talk',
+  title: 'A session',
+  speakers: [],
+  begin_time: '2026-08-17T01:00:00Z',
+  end_time: '2026-08-17T02:00:00Z',
+  recording_policy: true,
+  is_remote: false,
+  language: 'zh-hant',
+  python_level: 'NOVICE',
+  break_event: false,
+  custom_event: false,
+  custom_event_path: '',
+} satisfies ScheduleApiSlot
+
+describe('resolveRoomColumns', () => {
+  it('resolves a range expression to one spanning column', () => {
+    expect(resolveRoomColumns('=r0~r2', rooms)).toEqual([
+      { start: 1, span: 3 },
+    ])
+  })
+
+  it('resolves comma-separated rooms to independent columns', () => {
+    expect(resolveRoomColumns('=r1,r2', rooms)).toEqual([
+      { start: 2, span: 1 },
+      { start: 3, span: 1 },
+    ])
+  })
+
+  it('resolves mixed room and range expressions', () => {
+    expect(resolveRoomColumns('=r1,r2~r3', rooms)).toEqual([
+      { start: 2, span: 1 },
+      { start: 3, span: 2 },
+    ])
+  })
+
+  it('uses an exact room key before treating it as an expression', () => {
+    expect(resolveRoomColumns('=foo', rooms)).toEqual([
+      { start: 1, span: 2 },
+      { start: 3, span: 1 },
+    ])
+  })
+
+  it('does not parse a room id without the expression prefix', () => {
+    expect(resolveRoomColumns('r0~r2', rooms)).toBeUndefined()
+  })
+
+  it('only resolves rooms that define an expId', () => {
+    expect(resolveRoomColumns('=r1', rooms)).toEqual([{ start: 2, span: 1 }])
+    expect(resolveRoomColumns('=room-r0', rooms)).toBeUndefined()
+    expect(resolveRoomColumns('=room-without-exp-id', rooms)).toBeUndefined()
+    expect(resolveRoomColumns('=r0,unknown', rooms)).toBeUndefined()
+  })
+
+  it('rejects malformed expressions atomically', () => {
+    expect(resolveRoomColumns('=', rooms)).toBeUndefined()
+    expect(resolveRoomColumns('=r0,', rooms)).toBeUndefined()
+    expect(resolveRoomColumns('=r0~~r2', rooms)).toBeUndefined()
+  })
+
+  it('rejects expression rooms without a column', () => {
+    expect(resolveRoomColumns('=empty,r0', rooms)).toBeUndefined()
+    expect(resolveRoomColumns('=empty~r0', rooms)).toBeUndefined()
+  })
+})
+
+describe('normalizeConferenceScheduleDays', () => {
+  it('places slots from a dynamic room expression', () => {
+    const roomId = '=r1,r2~r3'
+    const day = {
+      date: '2026-08-17',
+      name: 'Day 1',
+      rooms: [roomId],
+      slots: { [roomId]: [slot] },
+    } satisfies ScheduleApiDay
+
+    const result = normalizeConferenceScheduleDays(day)
+    const expressionRooms = result.rooms.filter(room => room.id === roomId)
+
+    expect(expressionRooms.map(room => ({
+      placementId: room.placementId,
+      start: room.gridColumnStart,
+      span: room.gridColumnSpan,
+    }))).toEqual([
+      { placementId: `${roomId}:0`, start: 2, span: 1 },
+      { placementId: `${roomId}:1`, start: 3, span: 2 },
+    ])
+    expect(result.sessions.map(session => ({
+      roomId: session.roomId,
+      start: session.gridColumnStart,
+      span: session.gridColumnSpan,
+    }))).toEqual([
+      { roomId, start: 2, span: 1 },
+      { roomId, start: 3, span: 2 },
+    ])
+    expect(new Set(result.sessions.map(session => session.id)).size).toBe(2)
+  })
+})


### PR DESCRIPTION
<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes

* **New feature**

## Description

Support `=<exp>` for events custom location.

## Additional context

### 後台設定方法

<img width="504" height="96" alt="image" src="https://github.com/user-attachments/assets/a7fabed6-4130-4dee-96cd-3c9ce2bbbbbc" />


### `=r0~r2`
<img width="907" height="163" alt="截圖 2026-08-17 14 57 43" src="https://github.com/user-attachments/assets/156a3a66-e499-4053-b696-ee0b1d7d2028" />

### `=r0,r1,r2`
<img width="915" height="165" alt="截圖 2026-08-17 14 58 08" src="https://github.com/user-attachments/assets/33529e73-03c5-4406-9981-fbef1071c633" />

### `=r0,r2~r3`
<img width="913" height="171" alt="截圖 2026-08-17 14 58 24" src="https://github.com/user-attachments/assets/b3a78cc1-dd44-4224-9d3c-b2d6ee4dc9c9" />